### PR TITLE
fix : button starttracking block the last line surah

### DIFF
--- a/lib/pages/surat_page_v3/surat_page_v3.dart
+++ b/lib/pages/surat_page_v3/surat_page_v3.dart
@@ -491,6 +491,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
 
     if (orientation == Orientation.landscape) {
       return SingleChildScrollView(
+        controller: scrollController,
         padding: const EdgeInsets.only(top: 40),
         child: Column(
           mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
…l page

### Background

the surah is not shown 100% because closed by start tracking button 

### Video before

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/62508819/151b00de-20f2-4d94-94cc-b4a83e7613da

### Video After 

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/62508819/6ae0b57a-2927-4899-83af-673327a2127b



### Impacted Products

- surah page in full page mode landscape orientation

### How to Test

Please include steps of how you tested this changes

### Pre-Deployment Checklist

- [x] Run Local OK (Mandatory)
- [x] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
