### PR TITLE
feat: bottom sheet audio

### DIFF
--- a/lib/pages/home_page_v2/home_page_v2.dart
+++ b/lib/pages/home_page_v2/home_page_v2.dart
@@ -22,6 +22,7 @@ import 'package:qurantafsir_flutter/shared/core/providers.dart';
 import 'package:qurantafsir_flutter/shared/core/services/authentication_service.dart';
 import 'package:qurantafsir_flutter/shared/ui/state_notifier_connector.dart';
 import 'package:qurantafsir_flutter/shared/utils/date_util.dart' as date_util;
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart';
 import 'package:qurantafsir_flutter/widgets/button.dart';
 import 'package:qurantafsir_flutter/widgets/alert_dialog.dart';
 import 'package:qurantafsir_flutter/widgets/daily_progress_tracker.dart';
@@ -126,6 +127,15 @@ class _HomePageV2State extends State<HomePageV2> {
   }
 
   Future<void> _launchUrl(String? url) async {
+    // Todo delete this after testing
+    return GeneralBottomSheet.showBaseBottomSheet(
+      context: context,
+      widgetChild: const AudioBottomSheetWidget(
+        surahName: "Al Fatihah",
+        surahId: 1,
+        ayahId: 1,
+      ),
+    );
     final Uri _url = Uri.parse(url ?? '');
     if (!await launchUrl(_url)) {
       throw 'Could not launch $_url';

--- a/lib/shared/constants/button_audio_enum.dart
+++ b/lib/shared/constants/button_audio_enum.dart
@@ -1,0 +1,1 @@
+enum ButtonAudioState { paused, playing, loading }

--- a/lib/shared/core/providers.dart
+++ b/lib/shared/core/providers.dart
@@ -1,4 +1,6 @@
+import 'package:just_audio/just_audio.dart';
 import 'package:qurantafsir_flutter/main.dart';
+import 'package:qurantafsir_flutter/shared/constants/button_audio_enum.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_theme_data.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/tadabbur_api.dart';
 import 'package:qurantafsir_flutter/shared/core/services/alice_service.dart';
@@ -186,4 +188,39 @@ final Provider<TadabburService> tadabburService =
     sharedPreferenceService: sp,
     remoteConfigService: rc,
   );
+});
+
+final audioPlayerProvider = Provider<AudioPlayer>((ref) {
+  return AudioPlayer();
+});
+
+final currentDurationProvider = StreamProvider.autoDispose<Duration>((ref) {
+  final audioPlayer = ref.watch(audioPlayerProvider);
+
+  return audioPlayer.positionStream;
+});
+
+final totalDurationProvider = StreamProvider.autoDispose<Duration?>((ref) {
+  final audioPlayer = ref.watch(audioPlayerProvider);
+
+  return audioPlayer.durationStream;
+});
+
+final buttonAudioStateProvider =
+    StreamProvider.autoDispose<ButtonAudioState>((ref) {
+  final audioPlayer = ref.watch(audioPlayerProvider);
+
+  return audioPlayer.playerStateStream.map((event) {
+    final isPlaying = event.playing;
+    final processingState = event.processingState;
+
+    if (processingState == ProcessingState.loading ||
+        processingState == ProcessingState.buffering) {
+      return ButtonAudioState.loading;
+    } else if (!isPlaying) {
+      return ButtonAudioState.paused;
+    } else {
+      return ButtonAudioState.playing;
+    }
+  });
 });

--- a/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
+import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
+import 'package:qurantafsir_flutter/shared/core/providers.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart';
+
+class AudioBottomSheetWidget extends ConsumerStatefulWidget {
+  const AudioBottomSheetWidget({
+    required this.surahName,
+    required this.surahId,
+    required this.ayahId,
+    Key? key,
+  }) : super(key: key);
+  final String surahName;
+  final int surahId;
+  final int ayahId;
+  @override
+  ConsumerState<AudioBottomSheetWidget> createState() =>
+      _AudioBottomSheetWidgetState();
+}
+
+class _AudioBottomSheetWidgetState
+    extends ConsumerState<AudioBottomSheetWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final audioPlayer = ref.watch(audioPlayerProvider);
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: InkWell(
+                onTap: () => Navigator.pop(context),
+                child: const Align(
+                  alignment: Alignment.centerLeft,
+                  child: Icon(
+                    Icons.keyboard_arrow_down,
+                  ),
+                ),
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  widget.surahName,
+                  style: QPTextStyle.getSubHeading3SemiBold(context),
+                ),
+                Text(
+                  "Ayah ${widget.ayahId}",
+                  style: QPTextStyle.getDescription2Regular(context),
+                ),
+              ],
+            ),
+            const Spacer(),
+          ],
+        ),
+        const SizedBox(height: 20),
+        const LinearPercentIndicatorCustom(),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            children: [
+              const Spacer(),
+              InkWell(
+                onTap: () {
+                  audioPlayer.setUrl(
+                    "https://verses.quran.com/AbdulBaset/Mujawwad/mp3/001001.mp3",
+                  );
+                  audioPlayer.play();
+                },
+                child: Container(
+                  height: 36,
+                  width: 36,
+                  decoration: const BoxDecoration(
+                    color: QPColors.brandFair,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Row(
+                  children: [
+                    const SizedBox(
+                      width: 16,
+                    ),
+                    InkWell(
+                      child: Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: BoxDecoration(
+                          color: QPColors.whiteFair,
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(100)),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.1),
+                              blurRadius: 6,
+                              offset: const Offset(0, 4),
+                            ),
+                          ],
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.skip_next,
+                              size: 20,
+                            ),
+                            const SizedBox(width: 2),
+                            Text(
+                              "Al-Baqarah",
+                              style: QPTextStyle.getBody2Medium(context),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 30),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "Reciter",
+                  style: QPTextStyle.getDescription2Regular(context),
+                ),
+                Text(
+                  "Mishari Rashid al-`Afasy",
+                  style: QPTextStyle.getBody2Medium(context),
+                ),
+              ],
+            ),
+            const Icon(Icons.keyboard_arrow_right, size: 24),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
+++ b/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
@@ -1,0 +1,33 @@
+import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
+import 'package:qurantafsir_flutter/shared/core/providers.dart';
+
+class LinearPercentIndicatorCustom extends ConsumerWidget {
+  const LinearPercentIndicatorCustom({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentDuration = ref.watch(currentDurationProvider);
+    final totalDuration = ref.watch(totalDurationProvider);
+
+    return ProgressBar(
+      timeLabelTextStyle: QPTextStyle.getDescription2Regular(context),
+      progress: currentDuration.when(
+        data: (data) => data,
+        error: (error, st) => Duration.zero,
+        loading: () => Duration.zero,
+      ),
+      total: totalDuration.when(
+        data: (data) {
+          if (data != null) return data;
+
+          return Duration.zero;
+        },
+        error: (error, st) => Duration.zero,
+        loading: () => Duration.zero,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,6 +64,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
+  audio_service:
+    dependency: "direct main"
+    description:
+      name: audio_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.9"
+  audio_service_platform_interface:
+    dependency: transitive
+    description:
+      name: audio_service_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
+  audio_service_web:
+    dependency: transitive
+    description:
+      name: audio_service_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.13"
+  audio_video_progress_bar:
+    dependency: "direct main"
+    description:
+      name: audio_video_progress_bar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -667,6 +702,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.5"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.32"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.7"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,10 @@ dependencies:
   version: ^3.0.2
   store_redirect: ^2.0.1
   flutter_svg: ^1.0.3
+  audio_service: ^0.18.9
+  just_audio: ^0.9.32
+  audio_video_progress_bar: ^1.0.1
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Background

In this PR, I added a bottom sheet for playing audio. The approach I took was using the just_audio package. Then, I stored the audio player in the audioPlayerProvider, which is wrapped using a Provider.


Preview:



### Impacted Products

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/36232396/bc136c94-a75a-4368-98e2-82442c2ce74d



- Bottom Sheet Audio

### How to Test
- 

### Pre-Deployment Checklist

- [ ] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
