### PR TITLE
fix: cta play audio on ayah should be outlined

### DIFF
--- a/lib/pages/surat_page_v3/surat_page_v3.dart
+++ b/lib/pages/surat_page_v3/surat_page_v3.dart
@@ -948,7 +948,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
                             ),
                             padding: const EdgeInsets.all(0),
                             alignment: Alignment.centerLeft,
-                            icon: const Icon(Icons.play_circle),
+                            icon: const Icon(Icons.play_circle_outline),
                             iconSize: 20,
                             onPressed: () {
                               notifier.playOnAyah(verse);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.8.0+80
+version: 1.8.0+81
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
### Background

CTA play on ayah should be outlined, not filled

### Impacted Products

- Surah page

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/36220334/417217fe-b8a0-48a9-af4e-366eceec9c8e


### How to Test

Tested locally

### Pre-Deployment Checklist

- [x] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
