### PR TITLE
fix: reciter player minor bug fix

### DIFF
--- a/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
@@ -291,6 +291,7 @@ class _AudioBottomSheetWidgetState
                 title,
                 style: QPTextStyle.getBody2Medium(context),
                 overflow: TextOverflow.fade,
+                textAlign: TextAlign.right,
                 softWrap: false,
                 maxLines: 1,
               ),

--- a/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
@@ -83,6 +83,12 @@ class _AudioMinimizedInfoState extends ConsumerState<AudioMinimizedInfo> {
               icon: const Icon(Icons.close),
               iconSize: 24,
               onPressed: widget.onClose,
+              color: QPColors.getColorBasedTheme(
+                dark: QPColors.whiteFair,
+                light: QPColors.blackMassive,
+                brown: QPColors.brownModeMassive,
+                context: context,
+              ),
             ),
           ],
         ),

--- a/lib/widgets/audio_bottom_sheet/radio_button_change_reciter.dart
+++ b/lib/widgets/audio_bottom_sheet/radio_button_change_reciter.dart
@@ -86,8 +86,8 @@ class _RadioButtonSelectReciterWidgetState
                   data: (data) {
                     IconData icon =
                         item.id == playedId && data != ButtonAudioState.stop
-                            ? Icons.pause_circle_filled_rounded
-                            : Icons.play_circle_fill_rounded;
+                            ? Icons.pause
+                            : Icons.play_arrow;
 
                     return InkWell(
                       onTap: _onTapAudioPreviewReciter(
@@ -97,15 +97,8 @@ class _RadioButtonSelectReciterWidgetState
                       ),
                       child: Padding(
                         padding: const EdgeInsets.all(12),
-                        child: Icon(
-                          icon,
-                          color: QPColors.getColorBasedTheme(
-                            dark: QPColors.brandFair,
-                            light: QPColors.brandFair,
-                            brown: QPColors.brownModeMassive,
-                            context: context,
-                          ),
-                          size: 20,
+                        child: _IconButton(
+                          icon: icon,
                         ),
                       ),
                     );
@@ -150,5 +143,38 @@ class _RadioButtonSelectReciterWidgetState
 
       playedId = 0;
     };
+  }
+}
+
+class _IconButton extends StatelessWidget {
+  const _IconButton({
+    Key? key,
+    required this.icon,
+  }) : super(key: key);
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 18,
+      width: 18,
+      decoration: BoxDecoration(
+        color: QPColors.getColorBasedTheme(
+          dark: QPColors.brandFair,
+          light: QPColors.brandFair,
+          brown: QPColors.brownModeMassive,
+          context: context,
+        ),
+        shape: BoxShape.circle,
+      ),
+      child: Center(
+        child: Icon(
+          icon,
+          color: QPColors.whiteFair,
+          size: 12,
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
### Background

fixing minor bug from this feedback:

1. Bottom sheet select reciter - radio button pilihan reciter seharusnya align left (sejajar dgn tulisan select reciter) dan ada divider horizontal di setiap opsi reciter
2. Bottom sheet select reciter - button preview audio - fill button play seharusnya putih jika tema dark mode
3. Minimized player - button X nya belum bener utk dark mode

### Impacted Products

- audio_bottom_sheet_widget
- audio_minimized_info
- radio_button_change_reciter

### How to Test

Check on impacted products

### Screenshots

![Quran Plus Theme](https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/25982672/f510a3cf-6bd4-40a8-b694-026c8e45992b)

### Pre-Deployment Checklist

- [ ] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
