### PR TITLE
fix: ios cannot continue to next ayah

### DIFF
--- a/lib/pages/home_page_v2/home_page_state_notifier.dart
+++ b/lib/pages/home_page_v2/home_page_state_notifier.dart
@@ -134,21 +134,16 @@ class HomePageStateNotifier extends BaseStateNotifier<HomePageState> {
     required Function() onPlayBackError,
   }) async {
     _setAudioSuratLoaded(surat);
-    int reciterId;
-    String reciterName;
     final ReciterItemResponse? listReciterResponse =
         await _sharedPreferenceService.getSelectedReciter();
-
-    reciterId = listReciterResponse?.id ?? 1;
-    reciterName = listReciterResponse?.name ?? "Mishari Rashid Al-Afasy";
 
     final AudioRecitationState newState = AudioRecitationState(
       surahName: surat.nameLatin,
       surahId: int.parse(surat.number),
       ayahId: int.parse(surat.startAyat),
       isLoading: true,
-      reciterId: reciterId,
-      reciterName: reciterName,
+      reciterId: listReciterResponse?.id,
+      reciterName: listReciterResponse?.name,
     );
 
     await _audioRecitationNotifier.init(

--- a/lib/pages/surat_page_v3/surat_page_state_notifier.dart
+++ b/lib/pages/surat_page_v3/surat_page_state_notifier.dart
@@ -180,21 +180,16 @@ class SuratPageStateNotifier extends BaseStateNotifier<SuratPageState> {
   }
 
   Future<void> playOnAyah(Verse verse) async {
-    int reciterId;
-    String reciterName;
     final ReciterItemResponse? listReciterResponse =
         await _sharedPreferenceService.getSelectedReciter();
-
-    reciterId = listReciterResponse?.id ?? 1;
-    reciterName = listReciterResponse?.name ?? "Mishari Rashid Al-Afasy";
 
     final AudioRecitationState newState = AudioRecitationState(
       surahName: verse.surahName,
       surahId: verse.surahNumber,
       ayahId: verse.verseNumber,
       isLoading: true,
-      reciterId: reciterId,
-      reciterName: reciterName,
+      reciterId: listReciterResponse?.id,
+      reciterName: listReciterResponse?.name,
     );
 
     await _audioPlayerNotifier.init(newState);

--- a/lib/shared/core/services/audio_recitation/audio_recitation_handler.dart
+++ b/lib/shared/core/services/audio_recitation/audio_recitation_handler.dart
@@ -57,8 +57,10 @@ class AudioRecitationHandler extends BaseAudioHandler {
               MediaControl.skipToNext,
             ],
             systemActions: {},
-            processingState: const {
-              ProcessingState.idle: AudioProcessingState.idle,
+            processingState: {
+              ProcessingState.idle: Platform.isIOS
+                  ? AudioProcessingState.ready
+                  : AudioProcessingState.idle,
               ProcessingState.loading: AudioProcessingState.loading,
               ProcessingState.buffering: AudioProcessingState.buffering,
               ProcessingState.ready: AudioProcessingState.ready,

--- a/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
@@ -100,7 +100,7 @@ class AudioRecitationStateNotifier extends StateNotifier<AudioRecitationState> {
           shouldGoToNextSurah ? state.surahId + 1 : state.surahId;
       final int nextAyahNumber = shouldGoToNextSurah ? 1 : state.ayahId + 1;
 
-      MediaItem nextMedia = localPlaylist[localPlaylist.length - 1];
+      MediaItem nextMedia = localPlaylist.last;
 
       _audioHandler.setMediaItem(nextMedia);
       _audioHandler.play();

--- a/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
@@ -15,8 +15,8 @@ class AudioRecitationState {
     this.surahId = 1,
     this.ayahId = 1,
     this.isLoading = true,
-    this.reciterId,
-    this.reciterName,
+    this.reciterId = 1,
+    this.reciterName = 'Mishari Rashid Al-Afasy',
   });
 
   String surahName;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.8.0+86
+version: 1.8.0+90
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
### Background

Previously, iOS cannot play audio as what we expected. 

Problem : iOS cannot play next ayat if current ayat finished when app is on background (minimized)
Technical problem : iOS have some limitations, when an audio stopped for some time (for example for reloading a url, or hitting an API) iOS will teminate the runner
Solution : 
- Force iOS audio state when idle to `ready` so that iOS won't terminate the runner (ref : https://github.com/ryanheise/audio_service/issues/990#issuecomment-1403722072)
- Asynchronously load the next ayat, so the approach would be like this : 
  - First time play an ayat, we will hit our API 2 times. First for current ayat, the second for the next ayat
  - When changing ayat, audio handler will play the second ayat we have get before, then asynchronously hit API again to get the next ayat

### Video

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/36220334/07d6c50d-0f49-4240-9f65-742539719776

### Impacted Products

- Audio recitation player

### How to Test

- Tested locally
- Tested with external tester

### Pre-Deployment Checklist

- [x] Run Local OK (Mandatory)
- [x] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
