### PR TITLE
refactor: select reciter bottom sheet

### DIFF
--- a/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
@@ -5,12 +5,11 @@ import 'package:qurantafsir_flutter/shared/constants/button_audio_enum.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_buttom_sheet.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/Select_Reciter_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_buttom_sheet.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
-import 'package:qurantafsir_flutter/widgets/utils/general_dialog.dart';
 
 class AudioBottomSheetWidget extends ConsumerStatefulWidget {
   const AudioBottomSheetWidget({

--- a/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_minimized_info_icon_button.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
 
 class AudioMinimizedInfo extends ConsumerStatefulWidget {
   const AudioMinimizedInfo({

--- a/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
@@ -7,7 +7,7 @@ import 'package:qurantafsir_flutter/pages/surat_page_v3/utils.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/audio_api.dart';
 import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
 import 'package:qurantafsir_flutter/shared/core/services/audio_recitation/audio_recitation_handler.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/Select_Reciter_state_notifier.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart';
 
 class AudioRecitationState {
   AudioRecitationState({

--- a/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
+++ b/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
@@ -2,11 +2,9 @@ import 'package:audio_service/audio_service.dart';
 import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:just_audio/just_audio.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
-import 'package:qurantafsir_flutter/shared/core/services/audio_recitation/audio_recitation_handler.dart';
 
 class LinearPercentIndicatorCustom extends ConsumerWidget {
   const LinearPercentIndicatorCustom({Key? key}) : super(key: key);

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_audio_preview_button.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_audio_preview_button.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 
-class AudioPreviewReciterIconButton extends StatelessWidget {
-  const AudioPreviewReciterIconButton({
+class SelectReciterAudioPreviewButton extends StatelessWidget {
+  const SelectReciterAudioPreviewButton({
     Key? key,
     required this.icon,
   }) : super(key: key);

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_buttom_sheet.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_buttom_sheet.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
-
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/Select_Reciter_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/radio_button_change_reciter.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_radio_button.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/button.dart';
 import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 
@@ -40,7 +39,7 @@ class _SelectRecitatorWidgetState extends ConsumerState<SelectRecitatorWidget> {
         const SizedBox(
           height: 24,
         ),
-        const RadioButtonSelectReciter(),
+        const SelectReciterRadioButton(),
         const SizedBox(
           height: 16,
         ),

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_radio_button.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_radio_button.dart
@@ -5,20 +5,20 @@ import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/model/audio.dart';
 import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/Select_Reciter_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
-import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_preveiw_reciter_icon_button.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_audio_preview_button.dart';
+import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart';
 
-class RadioButtonSelectReciter extends ConsumerStatefulWidget {
-  const RadioButtonSelectReciter({Key? key}) : super(key: key);
+class SelectReciterRadioButton extends ConsumerStatefulWidget {
+  const SelectReciterRadioButton({Key? key}) : super(key: key);
 
   @override
-  ConsumerState<RadioButtonSelectReciter> createState() =>
+  ConsumerState<SelectReciterRadioButton> createState() =>
       _RadioButtonSelectReciterWidgetState();
 }
 
 class _RadioButtonSelectReciterWidgetState
-    extends ConsumerState<RadioButtonSelectReciter> {
+    extends ConsumerState<SelectReciterRadioButton> {
   int playedId = 0;
 
   @override
@@ -98,7 +98,7 @@ class _RadioButtonSelectReciterWidgetState
                       ),
                       child: Padding(
                         padding: const EdgeInsets.all(12),
-                        child: AudioPreviewReciterIconButton(
+                        child: SelectReciterAudioPreviewButton(
                           icon: icon,
                         ),
                       ),

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
 
-import 'package:audio_service/audio_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart';
-
 import 'package:qurantafsir_flutter/shared/core/apis/audio_api.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/model/audio.dart';
 import 'package:qurantafsir_flutter/shared/core/providers.dart';


### PR DESCRIPTION
### Background

move all related select reciter into select_reciter_bottom_sheet folder

### Impacted Products

- lib\widgets\audio_bottom_sheet\select_reciter_bottom_sheet\select_reciter_audio_preview_button.dart
- lib\widgets\audio_bottom_sheet\select_reciter_bottom_sheet\select_reciter_buttom_sheet.dart
- lib\widgets\audio_bottom_sheet\select_reciter_bottom_sheet\select_reciter_radio_button.dart
- lib\widgets\audio_bottom_sheet\select_reciter_bottom_sheet\select_reciter_state_notifier.dart

### How to Test

Check on impacted folder

### Pre-Deployment Checklist

- [ ] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
