### PR TITLE
fix: widget audio player ayah id minus 1

### DIFF
--- a/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
@@ -77,6 +77,12 @@ class AudioRecitationStateNotifier extends StateNotifier<AudioRecitationState> {
         ayahNumber: nextAyahNumber,
       );
 
+      state = state.copyWith(
+        surahId: nextSurahId,
+        ayahId: nextAyahNumber,
+        surahName: surahNumberToSurahNameMap[nextSurahId] ?? '',
+      );
+
       _audioHandler.setMediaItem(
         MediaItem(
           id: '${state.surahId}-${state.ayahId}-${state.reciterId}',
@@ -89,12 +95,6 @@ class AudioRecitationStateNotifier extends StateNotifier<AudioRecitationState> {
         ),
       );
       _audioHandler.play();
-
-      state = state.copyWith(
-        surahId: nextSurahId,
-        ayahId: nextAyahNumber,
-        surahName: surahNumberToSurahNameMap[nextSurahId] ?? '',
-      );
     } catch (e) {
       //TODO Add error tracker
     }


### PR DESCRIPTION
### Background

Audio player widget showing current ayah number n-1 (ex: current audio is playing Al-Fatihah ayah 5, but in the widget showing Al-Fatihah ayah 4)

### Impacted Products

- Audio Player Widget

### How to Test

Play ayah and see what is the current ayah id

### Video

https://github.com/Yaumi-Digital-School/quranplus-flutter/assets/25982672/8b6b9ab1-b589-4cc3-9c05-d809d914664a


### Pre-Deployment Checklist

- [ ] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
