### PR TITLE
chore: add bump build script

### DIFF
--- a/.github/workflows/bump_build.yml
+++ b/.github/workflows/bump_build.yml
@@ -28,5 +28,4 @@ jobs:
 
       - name: Bump build number
         run: |
-          cd ../..
           ./scripts/increment_build.sh

--- a/.github/workflows/bump_build.yml
+++ b/.github/workflows/bump_build.yml
@@ -6,8 +6,6 @@
 name: bump_build
 
 on:
-  push:
-    branches: [ "chore/add_bump_build_script" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/bump_build.yml
+++ b/.github/workflows/bump_build.yml
@@ -1,0 +1,30 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: bump_build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Note: This workflow uses the latest stable version of the Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/dart-lang/setup-dart/blob/main/README.md
+      # - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+
+      - name: Install Cider
+        run: dart pub global activate cider
+
+      - name: Bump build number
+        run: |
+          cd ../..
+          ./scripts/increment_build.sh

--- a/.github/workflows/bump_build.yml
+++ b/.github/workflows/bump_build.yml
@@ -1,12 +1,11 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: bump_build
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'branch name to run job'
+        default: "master"
 
 jobs:
   build:

--- a/.github/workflows/bump_build.yml
+++ b/.github/workflows/bump_build.yml
@@ -6,6 +6,8 @@
 name: bump_build
 
 on:
+  push:
+    branches: [ "chore/add_bump_build_script" ]
   workflow_dispatch:
 
 jobs:

--- a/scripts/increment_build.sh
+++ b/scripts/increment_build.sh
@@ -1,0 +1,11 @@
+cider bump build
+
+BUILD_NUMBER=$(echo $(cider version) | cut -d '+' -f 2)
+BRANCH_NAME="build$BUILD_NUMBER"
+git checkout -b $BRANCH_NAME
+
+git add pubspec.yaml
+
+git commit -m "chore: bump build number to $BUILD_NUMBER"
+
+git push origin $BRANCH_NAME


### PR DESCRIPTION
### Background

Script to increase build number and push it directly to repo

How to use ?

run `pub global activate cider` locally

then, run `./scripts/increment_build.sh` or run `bump_build` job

after that, create a PR for that branch. Branch name should be `buildXX` XX means incremented build number

### Impacted Products

-

### How to Test

-

### Pre-Deployment Checklist

- [x] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
