### PR TITLE
refactor: modernize syntax by using super parameters and update depercated CupertinoSwitch propertie

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,64 +5,17 @@
 # IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
 # invoked from the command line by running `flutter analyze`.
 
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+
 linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
-
-analyzer:
-  plugins:
-    - dart_code_metrics
-
-dart_code_metrics:
-  metrics:
-    cyclomatic-complexity: 20
-    maximum-nesting-level: 5
-    number-of-parameters: 4
-    source-lines-of-code: 50
-  metrics-exclude:
-    - test/**
-  rules:
-    - prefer-trailing-comma:
-        break-on: 4
-        severity: error
-    - avoid-border-all:
-        severity: error
-    - avoid-expanded-as-spacer:
-        severity: error
-    - avoid-shrink-wrap-in-lists:
-        severity: error
-    - avoid-unnecessary-setstate:
-        severity: error
-    - avoid-wrapping-in-padding:
-        severity: error
-    - prefer-const-border-radius:
-        severity: error
-    - prefer-using-list-view:
-        severity: error
-    - avoid-double-slash-imports:
-        severity: error
-    - avoid-duplicate-exports:
-        severity: error
-    - newline-before-return:
-        severity: error
-    - no-boolean-literal-compare:
-        severity: error

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,6 @@ Future<void> main() async {
   await NotificationService().init();
   await Workmanager().initialize(
     callbackDispatcher,
-    isInDebugMode: true,
   );
 
   final AudioRecitationHandler currentAudioHandler =
@@ -100,7 +99,7 @@ void callbackDispatcher() {
 }
 
 class MyApp extends ConsumerStatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   static FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   static FirebaseAnalyticsObserver observer =

--- a/lib/pages/account_deletion/account_deletion_view.dart
+++ b/lib/pages/account_deletion/account_deletion_view.dart
@@ -13,8 +13,8 @@ import 'package:qurantafsir_flutter/widgets/snackbar.dart';
 
 class AccountDeletionInformationView extends StatelessWidget {
   const AccountDeletionInformationView({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -15,7 +15,7 @@ import 'package:qurantafsir_flutter/widgets/button.dart';
 import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 
 class AccountPage extends StatelessWidget {
-  AccountPage({Key? key}) : super(key: key);
+  AccountPage({super.key});
 
   final List<String> _genderType = ['Male', 'Female'];
 
@@ -333,46 +333,49 @@ class AccountPage extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      for (var item in _genderType) ...[
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Container(
-                              width: 24,
-                              height: 24,
-                              margin: const EdgeInsets.only(right: 8),
-                              child: Radio(
-                                value: item[0],
-                                groupValue: state.gender,
-                                fillColor:
-                                    MaterialStateProperty.resolveWith<Color>(
-                                  (Set<MaterialState> states) {
-                                    return Theme.of(context)
-                                        .colorScheme
-                                        .primary;
-                                  },
+                  RadioGroup<String>(
+                    groupValue: state.gender,
+                    onChanged: (value) {
+                      notifier.genderChanged(value);
+                    },
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        for (var item in _genderType) ...[
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Container(
+                                width: 24,
+                                height: 24,
+                                margin: const EdgeInsets.only(right: 8),
+                                child: Radio(
+                                  value: item[0],
+                                  fillColor:
+                                      WidgetStateProperty.resolveWith<Color>(
+                                    (Set<WidgetState> states) {
+                                      return Theme.of(context)
+                                          .colorScheme
+                                          .primary;
+                                    },
+                                  ),
+                                  activeColor:
+                                      Theme.of(context).colorScheme.primary,
                                 ),
-                                activeColor:
-                                    Theme.of(context).colorScheme.primary,
-                                onChanged: (value) {
-                                  notifier.genderChanged(value);
-                                },
                               ),
-                            ),
-                            Text(
-                              item,
-                              style: QPTextStyle.getSubHeading3Regular(context),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(width: 24),
+                              Text(
+                                item,
+                                style:
+                                    QPTextStyle.getSubHeading3Regular(context),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(width: 24),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                   if (state.formStatus == FormStatus.invalid &&
                       state.gender.isEmpty) ...[

--- a/lib/pages/bookmark_v2/bookmark_page_v2.dart
+++ b/lib/pages/bookmark_v2/bookmark_page_v2.dart
@@ -18,17 +18,17 @@ import 'package:qurantafsir_flutter/shared/ui/state_notifier_connector.dart';
 
 // TODO: we need to refactor this file into separate file
 class BookmarkPageV2 extends StatelessWidget {
-  const BookmarkPageV2({Key? key}) : super(key: key);
+  const BookmarkPageV2({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         final navigationBar =
             mainNavbarGlobalKey.currentWidget as BottomNavigationBar;
         navigationBar.onTap!(0);
-
-        return false;
       },
       child:
           StateNotifierConnector<BookmarkPageStateNotifier, BookmarkPageState>(
@@ -97,7 +97,7 @@ class BookmarkPageV2 extends StatelessWidget {
                             const BorderRadius.all(Radius.circular(20)),
                         boxShadow: <BoxShadow>[
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.1),
+                            color: Colors.black.withValues(alpha: 0.1),
                             blurRadius: 12,
                             offset: const Offset(0, 4),
                           ),
@@ -395,7 +395,7 @@ class BookmarkPageV2 extends StatelessWidget {
               ),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.1),
+                  color: Colors.black.withValues(alpha: 0.1),
                   blurRadius: 6,
                   offset: const Offset(0, 0.9),
                 ),

--- a/lib/pages/habit_group_detail/habit_group_detail_view.dart
+++ b/lib/pages/habit_group_detail/habit_group_detail_view.dart
@@ -31,9 +31,9 @@ class HabitGroupDetailViewParam {
 
 class HabitGroupDetailView extends StatefulWidget {
   const HabitGroupDetailView({
-    Key? key,
+    super.key,
     required this.param,
-  }) : super(key: key);
+  });
 
   final HabitGroupDetailViewParam param;
 
@@ -66,6 +66,7 @@ class _HabitGroupDetailViewState extends State<HabitGroupDetailView> {
 
         if (widget.param.isSuccessJoinGroup) {
           Future.delayed(const Duration(seconds: 1), () {
+            if (!context.mounted) return;
             HabitGroupBottomSheet.showModalSuccessJoinGroup(context: context);
           });
         }
@@ -86,6 +87,7 @@ class _HabitGroupDetailViewState extends State<HabitGroupDetailView> {
 
         if (state.userSummaryResponse != null) {
           Future.delayed(const Duration(milliseconds: 0), () {
+            if (!context.mounted) return;
             UserSummaryBottomSheet.showBottomSheet(
               context: context,
               data: state.userSummaryResponse!,
@@ -94,9 +96,11 @@ class _HabitGroupDetailViewState extends State<HabitGroupDetailView> {
           });
         }
 
-        return WillPopScope(
-          onWillPop: () async {
-            return _onTapBack(context, ref, notifier.groupNameIsEdited);
+        return PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, result) {
+            if (didPop) return;
+            _onTapBack(context, ref, notifier.groupNameIsEdited);
           },
           child: Scaffold(
             appBar: PreferredSize(
@@ -285,7 +289,7 @@ class _HabitGroupDetailViewState extends State<HabitGroupDetailView> {
                 ),
                 if (state.isFetchUserSummary)
                   Container(
-                    color: Colors.black.withOpacity(0.3),
+                    color: Colors.black.withValues(alpha: 0.3),
                     height: double.infinity,
                     width: double.infinity,
                     child: const Center(
@@ -398,12 +402,11 @@ class _HabitGroupDetailViewState extends State<HabitGroupDetailView> {
     final uri =
         await DynamicLinkHelper().createDynamicLinkInvite(id: widget.param.id);
 
-    if (mounted) {
-      HabitGroupBottomSheet.showModalInviteMemberGroup(
-        context: context,
-        url: uri.toString(),
-        currentGroupName: state.groupName,
-      );
-    }
+    if (!context.mounted) return;
+    HabitGroupBottomSheet.showModalInviteMemberGroup(
+      context: context,
+      url: uri.toString(),
+      currentGroupName: state.groupName,
+    );
   }
 }

--- a/lib/pages/habit_page/habit_page.dart
+++ b/lib/pages/habit_page/habit_page.dart
@@ -9,23 +9,22 @@ import 'package:qurantafsir_flutter/shared/utils/authentication_status.dart';
 import 'package:qurantafsir_flutter/widgets/registration_view/registration_view.dart';
 
 class HabitPage extends StatelessWidget {
-  const HabitPage({Key? key}) : super(key: key);
+  const HabitPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         final navigationBar =
             mainNavbarGlobalKey.currentWidget as BottomNavigationBar;
         navigationBar.onTap!(0);
-
-        return false;
       },
       child: StateNotifierConnector<HabitPageStateNotifier, HabitPageState>(
         stateNotifierProvider:
             StateNotifierProvider<HabitPageStateNotifier, HabitPageState>(
-          (StateNotifierProviderRef<HabitPageStateNotifier, HabitPageState>
-              ref) {
+          (Ref ref) {
             return HabitPageStateNotifier(
               repository: ref.watch(authenticationService),
               sharedPreferenceService:

--- a/lib/pages/habit_page/habit_progress/habit_progress_view.dart
+++ b/lib/pages/habit_page/habit_progress/habit_progress_view.dart
@@ -17,7 +17,6 @@ extension HabitProgressTabIndex on HabitProgressTab {
       case HabitProgressTab.group:
         return 1;
       case HabitProgressTab.personal:
-      default:
         return 0;
     }
   }
@@ -25,8 +24,8 @@ extension HabitProgressTabIndex on HabitProgressTab {
 
 class HabitProgressView extends ConsumerStatefulWidget {
   const HabitProgressView({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   ConsumerState<HabitProgressView> createState() => _HabitProgressViewState();
@@ -62,7 +61,7 @@ class _HabitProgressViewState extends ConsumerState<HabitProgressView> {
             ),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.1),
+                color: Colors.black.withValues(alpha: 0.1),
                 offset: const Offset(0, 4),
                 blurRadius: 10,
                 spreadRadius: 1,

--- a/lib/pages/habit_page/habit_progress/widgets/add_daily_progress_manual/add_daily_progress_manual_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/add_daily_progress_manual/add_daily_progress_manual_view.dart
@@ -13,8 +13,7 @@ import 'package:qurantafsir_flutter/widgets/text_field.dart';
 
 class AddDailyProgressManualView extends StatefulWidget {
   final HabitDailySummary habitDailySummary;
-  const AddDailyProgressManualView({Key? key, required this.habitDailySummary})
-      : super(key: key);
+  const AddDailyProgressManualView({super.key, required this.habitDailySummary});
 
   @override
   State<AddDailyProgressManualView> createState() =>
@@ -35,9 +34,7 @@ class _AddDailyProgressManualViewState
         AddDailyProgressManualState>(
       stateNotifierProvider: StateNotifierProvider<
           AddDailyProgressManualStateNotifier, AddDailyProgressManualState>(
-        (StateNotifierProviderRef<AddDailyProgressManualStateNotifier,
-                AddDailyProgressManualState>
-            ref) {
+        (Ref ref) {
           return AddDailyProgressManualStateNotifier(
             habitDailySummary: widget.habitDailySummary,
           );

--- a/lib/pages/habit_page/habit_progress/widgets/change_daily_target/change_daily_target_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/change_daily_target/change_daily_target_view.dart
@@ -14,9 +14,9 @@ const list = ['Pages', 'Juz'];
 class ChangeDailyTargetView extends StatefulWidget {
   final HabitDailySummary habitDailySummary;
   const ChangeDailyTargetView({
-    Key? key,
+    super.key,
     required this.habitDailySummary,
-  }) : super(key: key);
+  });
 
   @override
   State<ChangeDailyTargetView> createState() => _ChangeDailyTargetViewState();
@@ -32,9 +32,7 @@ class _ChangeDailyTargetViewState extends State<ChangeDailyTargetView> {
         ChangeDailyTargetState>(
       stateNotifierProvider: StateNotifierProvider<
           ChangeDailyTargetStateNotifier, ChangeDailyTargetState>(
-        (StateNotifierProviderRef<ChangeDailyTargetStateNotifier,
-                ChangeDailyTargetState>
-            ref) {
+        (Ref ref) {
           return ChangeDailyTargetStateNotifier(
             habitDailySummary: widget.habitDailySummary,
           );
@@ -140,9 +138,9 @@ class DropDownListChangeTarget extends StatefulWidget {
   final void Function(String) onChanged;
 
   const DropDownListChangeTarget({
-    Key? key,
+    super.key,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   State<DropDownListChangeTarget> createState() =>

--- a/lib/pages/habit_page/habit_progress/widgets/habit_group/habit_group_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/habit_group/habit_group_view.dart
@@ -13,15 +13,14 @@ import 'widgets/habit_group_create_group_bottom_sheet.dart';
 import 'habit_group_state_notifier.dart';
 
 class HabitGroupView extends StatelessWidget {
-  const HabitGroupView({Key? key}) : super(key: key);
+  const HabitGroupView({super.key});
 
   @override
   Widget build(BuildContext context) {
     return StateNotifierConnector<HabitGroupStateNotifier, HabitGroupState>(
       stateNotifierProvider:
           StateNotifierProvider<HabitGroupStateNotifier, HabitGroupState>(
-        (StateNotifierProviderRef<HabitGroupStateNotifier, HabitGroupState>
-            ref) {
+        (Ref ref) {
           return HabitGroupStateNotifier(
             habitGroupApi: ref.watch(habitGroupApiProvider),
           );

--- a/lib/pages/habit_page/habit_progress/widgets/habit_group/widgets/habit_group_empty_group_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/habit_group/widgets/habit_group_empty_group_view.dart
@@ -5,9 +5,9 @@ import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 
 class HabitGroupEmptyGroupView extends StatelessWidget {
   const HabitGroupEmptyGroupView({
-    Key? key,
+    super.key,
     required this.onSubmitCreateGroup,
-  }) : super(key: key);
+  });
 
   final Future<void> Function(String) onSubmitCreateGroup;
 
@@ -62,7 +62,7 @@ class HabitGroupEmptyGroupView extends StatelessWidget {
           borderRadius: const BorderRadius.all(Radius.circular(8)),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: 0.1),
               offset: const Offset(0, 4),
               blurRadius: 10,
               spreadRadius: 1,

--- a/lib/pages/habit_page/habit_progress/widgets/habit_group/widgets/habit_group_list_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/habit_group/widgets/habit_group_list_view.dart
@@ -10,8 +10,8 @@ class HabitGroupListView extends StatelessWidget {
   const HabitGroupListView({
     required this.listGroup,
     this.onEditedGroupName,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final List<GetHabitGroupsItem> listGroup;
   final Future<void> Function()? onEditedGroupName;

--- a/lib/pages/habit_page/habit_progress/widgets/habit_personal/habit_personal_view.dart
+++ b/lib/pages/habit_page/habit_progress/widgets/habit_personal/habit_personal_view.dart
@@ -18,7 +18,7 @@ import 'package:qurantafsir_flutter/widgets/utils/general_dialog.dart';
 import 'habit_personal_state_notifier.dart';
 
 class HabitPersonalView extends StatefulWidget {
-  const HabitPersonalView({Key? key}) : super(key: key);
+  const HabitPersonalView({super.key});
 
   @override
   State<HabitPersonalView> createState() => _HabitPersonalState();
@@ -31,9 +31,7 @@ class _HabitPersonalState extends State<HabitPersonalView> {
         HabitPersonalState>(
       stateNotifierProvider:
           StateNotifierProvider<HabitPersonalStateNotifier, HabitPersonalState>(
-        (StateNotifierProviderRef<HabitPersonalStateNotifier,
-                HabitPersonalState>
-            ref) {
+        (Ref ref) {
           return HabitPersonalStateNotifier(
             habitDailySummaryService: ref.watch(habitDailySummaryService),
           );

--- a/lib/pages/home_page_v2/home_page_v2.dart
+++ b/lib/pages/home_page_v2/home_page_v2.dart
@@ -35,8 +35,8 @@ import 'widgets/adzan_card/adzan_card_widget.dart';
 
 class HomePageV2 extends StatefulWidget {
   const HomePageV2({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<HomePageV2> createState() => _HomePageV2State();
@@ -105,6 +105,7 @@ class _HomePageV2State extends State<HomePageV2> {
     WidgetRef ref,
   ) {
     Future.delayed(Duration.zero, () {
+      if (!mounted) return;
       SignInBottomSheet.show(
         context: context,
         onClose: () {
@@ -133,9 +134,11 @@ class _HomePageV2State extends State<HomePageV2> {
           type: type,
         );
 
-    if (result == SignInResult.failedAccountDeleted && context.mounted) {
+    if (result == SignInResult.failedAccountDeleted) {
+      if (!mounted) return;
       Navigator.pop(context);
       await Future.delayed(const Duration(seconds: 1), () {
+        if (!mounted) return;
         SignInBottomSheet.showAccountDeletedInfo(context: context);
       });
 
@@ -158,9 +161,8 @@ class _HomePageV2State extends State<HomePageV2> {
         req.response.statusCode == 200 &&
         param != null;
 
-    if (context.mounted) {
-      Navigator.pop(context);
-    }
+    if (!mounted) return;
+    Navigator.pop(context);
 
     if (shouldRedirect) {
       Object? args;
@@ -172,13 +174,12 @@ class _HomePageV2State extends State<HomePageV2> {
           );
       }
 
-      if (context.mounted) {
-        Navigator.pushNamed(
-          context,
-          param.nextPath ?? '',
-          arguments: args,
-        );
-      }
+      if (!mounted) return;
+      Navigator.pushNamed(
+        context,
+        param.nextPath ?? '',
+        arguments: args,
+      );
     }
 
     if (req.response.statusCode == 400) {
@@ -190,6 +191,7 @@ class _HomePageV2State extends State<HomePageV2> {
 
   void _showInvalidLinkBottomSheet() {
     Future.delayed(Duration.zero, () {
+      if (!mounted) return;
       GeneralBottomSheet.showBaseBottomSheet(
         context: context,
         widgetChild: _getErrorWidget(
@@ -202,6 +204,7 @@ class _HomePageV2State extends State<HomePageV2> {
 
   void _showInvalidGroupBottomSheet() {
     Future.delayed(Duration.zero, () {
+      if (!mounted) return;
       GeneralBottomSheet.showBaseBottomSheet(
         context: context,
         widgetChild: _getErrorWidget(
@@ -256,10 +259,10 @@ const double diameterButtonSearch = 65;
 
 class ListSuratByJuz extends StatelessWidget {
   const ListSuratByJuz({
-    Key? key,
+    super.key,
     required this.notifier,
     required this.parentState,
-  }) : super(key: key);
+  });
 
   final HomePageStateNotifier notifier;
   final HomePageState parentState;
@@ -440,7 +443,7 @@ class ListSuratByJuz extends StatelessWidget {
         borderRadius: const BorderRadius.all(Radius.circular(15)),
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 12,
             offset: const Offset(0, 4),
           ),
@@ -838,10 +841,9 @@ class ListSuratByJuz extends StatelessWidget {
 
 class _ButtonSearch extends StatelessWidget {
   const _ButtonSearch({
-    Key? key,
     required this.versePagetoAyah,
     required this.state,
-  }) : super(key: key);
+  });
 
   final Map<String, List<String>>? versePagetoAyah;
   final HomePageState state;
@@ -871,7 +873,7 @@ class _ButtonSearch extends StatelessWidget {
 }
 
 class _ListSurahByJuzSkeleton extends StatelessWidget {
-  const _ListSurahByJuzSkeleton({Key? key}) : super(key: key);
+  const _ListSurahByJuzSkeleton();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/home_page_v2/widgets/card_start_habit.dart
+++ b/lib/pages/home_page_v2/widgets/card_start_habit.dart
@@ -4,7 +4,7 @@ import 'package:qurantafsir_flutter/shared/constants/image.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 
 class StartHabitCard extends StatelessWidget {
-  const StartHabitCard({Key? key}) : super(key: key);
+  const StartHabitCard({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +15,7 @@ class StartHabitCard extends StatelessWidget {
         borderRadius: const BorderRadius.all(Radius.circular(15)),
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 12,
             offset: const Offset(0, 4),
           ),

--- a/lib/pages/home_page_v2/widgets/daily_progress_tracker_detail_card/daily_progress_tracker_detail_card.dart
+++ b/lib/pages/home_page_v2/widgets/daily_progress_tracker_detail_card/daily_progress_tracker_detail_card.dart
@@ -15,13 +15,13 @@ import 'package:shimmer/shimmer.dart';
 
 class DailyProgressTrackerDetailCard extends StatelessWidget {
   const DailyProgressTrackerDetailCard({
-    Key? key,
+    super.key,
     required this.dailySummary,
     this.isNeedSync = false,
     this.lastTrackedData,
     this.lastBookmark,
     this.onRefreshParentWidget,
-  }) : super(key: key);
+  });
 
   final HabitDailySummary dailySummary;
   final LastRecordingData? lastTrackedData;
@@ -47,7 +47,7 @@ class DailyProgressTrackerDetailCard extends StatelessWidget {
         borderRadius: const BorderRadius.all(Radius.circular(15)),
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 12,
             offset: const Offset(0, 4),
           ),
@@ -101,7 +101,7 @@ class DailyProgressTrackerDetailCard extends StatelessWidget {
         borderRadius: const BorderRadius.all(Radius.circular(15)),
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 12,
             offset: const Offset(0, 4),
           ),
@@ -362,7 +362,7 @@ class DailyProgressTrackerDetailCard extends StatelessWidget {
 }
 
 class DailyProgressTrackerSkeleton extends StatelessWidget {
-  const DailyProgressTrackerSkeleton({Key? key}) : super(key: key);
+  const DailyProgressTrackerSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/main_page/main_page.dart
+++ b/lib/pages/main_page/main_page.dart
@@ -19,9 +19,9 @@ GlobalKey mainNavbarGlobalKey = GlobalKey<State<BottomNavigationBar>>();
 
 class MainPage extends StatefulWidget {
   const MainPage({
-    Key? key,
+    super.key,
     this.param,
-  }) : super(key: key);
+  });
 
   final MainPageParam? param;
 

--- a/lib/pages/prayer_time_page/prayer_time.dart
+++ b/lib/pages/prayer_time_page/prayer_time.dart
@@ -12,7 +12,7 @@ import 'package:qurantafsir_flutter/shared/core/providers/prayer_times_notifier.
 import 'package:qurantafsir_flutter/shared/ui/state_notifier_connector.dart';
 
 class PrayerTimePage extends ConsumerStatefulWidget {
-  const PrayerTimePage({Key? key}) : super(key: key);
+  const PrayerTimePage({super.key});
 
   @override
   ConsumerState<PrayerTimePage> createState() => _PrayerTimePageState();
@@ -218,7 +218,7 @@ class _PrayerTimePageState extends ConsumerState<PrayerTimePage> {
                             Transform.scale(
                               scale: 0.7,
                               child: CupertinoSwitch(
-                                activeColor: QPColors.brandHeavy,
+                                activeTrackColor: QPColors.brandHeavy,
                                 value: state.locationIsOn,
                                 onChanged: (value) {
                                   if (value != state.locationIsOn) {

--- a/lib/pages/read_tadabbur/read_tadabbur_page.dart
+++ b/lib/pages/read_tadabbur/read_tadabbur_page.dart
@@ -25,7 +25,7 @@ class ReadTadabburParam {
 
 class ReadTadabburPage extends StatelessWidget {
   final ReadTadabburParam param;
-  const ReadTadabburPage({required this.param, Key? key}) : super(key: key);
+  const ReadTadabburPage({required this.param, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -140,7 +140,7 @@ class ReadTadabburPage extends StatelessWidget {
                 ),
               if (state.isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   height: double.infinity,
                   width: double.infinity,
                   child: const Center(

--- a/lib/pages/read_tadabbur/widgets/tadabbur_ayah_card.dart
+++ b/lib/pages/read_tadabbur/widgets/tadabbur_ayah_card.dart
@@ -7,14 +7,14 @@ import 'package:qurantafsir_flutter/shared/utils/date_util.dart';
 
 class TadabburAyahCard extends StatelessWidget {
   const TadabburAyahCard({
-    Key? key,
+    super.key,
     required this.ayahNumber,
     required this.title,
     required this.source,
     required this.createdAt,
     required this.surahNumber,
     required this.tadabburId,
-  }) : super(key: key);
+  });
 
   final String title;
   final String source;

--- a/lib/pages/settings_page/settings_page.dart
+++ b/lib/pages/settings_page/settings_page.dart
@@ -22,25 +22,23 @@ import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 import 'package:qurantafsir_flutter/widgets/horizontal_divider.dart';
 
 class SettingsPage extends StatelessWidget {
-  const SettingsPage({Key? key}) : super(key: key);
+  const SettingsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         final navigationBar =
             mainNavbarGlobalKey.currentWidget as BottomNavigationBar;
         navigationBar.onTap!(0);
-
-        return false;
       },
       child:
           StateNotifierConnector<SettingsPageStateNotifier, SettingsPageState>(
         stateNotifierProvider:
             StateNotifierProvider<SettingsPageStateNotifier, SettingsPageState>(
-          (StateNotifierProviderRef<SettingsPageStateNotifier,
-                  SettingsPageState>
-              ref) {
+          (Ref ref) {
             return SettingsPageStateNotifier(
               repository: ref.watch(authenticationService),
               sharedPreferenceService:

--- a/lib/pages/settings_page/widgets/settings_page_menu_item.dart
+++ b/lib/pages/settings_page/widgets/settings_page_menu_item.dart
@@ -12,8 +12,8 @@ class SettingsPageMenuItem extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.customColor,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final StoredIcon? icon;
   final IconData? iconData;

--- a/lib/pages/settings_page/widgets/version_app_widget.dart
+++ b/lib/pages/settings_page/widgets/version_app_widget.dart
@@ -4,7 +4,7 @@ import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 
 class VersionAppWidget extends StatefulWidget {
-  const VersionAppWidget({Key? key, this.title}) : super(key: key);
+  const VersionAppWidget({super.key, this.title});
 
   final String? title;
 

--- a/lib/pages/splash_page/splash_page.dart
+++ b/lib/pages/splash_page/splash_page.dart
@@ -17,7 +17,7 @@ import 'package:qurantafsir_flutter/widgets/utils/general_dialog.dart';
 
 class SplashPage extends StatefulWidget {
   final GlobalKey<NavigatorState> navigatorKey;
-  const SplashPage({required this.navigatorKey, Key? key}) : super(key: key);
+  const SplashPage({required this.navigatorKey, super.key});
 
   @override
   State<SplashPage> createState() => _SplashPageState();
@@ -110,7 +110,6 @@ class _SplashPageState extends State<SplashPage> {
         dialog = const ForceUpdateDialog();
         break;
       case AppUpdateType.optionalUpdate:
-      default:
         if (!info.shouldShowUpdateMinVersion) {
           return;
         }

--- a/lib/pages/splash_page/splash_page_state_notifier.dart
+++ b/lib/pages/splash_page/splash_page_state_notifier.dart
@@ -75,7 +75,7 @@ class SplashPageStateNotifier extends BaseStateNotifier<SplashPageState> {
         stackTrace,
         reason: 'error on initstate() method in splash screen',
       );
-      print(error);
+      debugPrint(error.toString());
     }
   }
 

--- a/lib/pages/surat_page_v3/surat_page_v3.dart
+++ b/lib/pages/surat_page_v3/surat_page_v3.dart
@@ -79,9 +79,9 @@ class SuratPageV3Param {
 
 class SuratPageV3 extends ConsumerStatefulWidget {
   const SuratPageV3({
-    Key? key,
+    super.key,
     required this.param,
-  }) : super(key: key);
+  });
 
   final SuratPageV3Param param;
 
@@ -136,6 +136,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
       onStateNotifierReady: (notifier, ref) async {
         if (widget.param.isStartTracking) {
           Future.delayed(Duration.zero, () {
+            if (!context.mounted) return;
             _startTracking(context, notifier);
           });
         }
@@ -173,11 +174,15 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
 
         final connectivityStatus = ref.watch(internetConnectionStatusProviders);
 
-        return WillPopScope(
-          onWillPop: () async => _onTapBack(
-            notifier: notifier,
-            state: state,
-          ),
+        return PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, result) {
+            if (didPop) return;
+            _onTapBack(
+              notifier: notifier,
+              state: state,
+            );
+          },
           child: Scaffold(
             key: _scaffoldKey,
             appBar: PreferredSize(
@@ -204,7 +209,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
                       valueListenable: notifier.visibleSuratName,
                       builder: (context, value, __) {
                         return Text(
-                          '$value',
+                          value,
                           style: QPTextStyle.getSubHeading2SemiBold(context),
                         );
                       },
@@ -494,6 +499,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
                                         .read(suratPageProvider.notifier)
                                         .initStateNotifier();
                                     Future.delayed(Duration.zero, () {
+                                      if (!context.mounted) return;
                                       _startTracking(
                                         context,
                                         ref.read(suratPageProvider.notifier),
@@ -1089,7 +1095,7 @@ class _SuratPageV3State extends ConsumerState<SuratPageV3> {
                               .copyWith(
                             color: QPColors.getColorBasedTheme(
                               dark: QPColors.blackSoft,
-                              light: Colors.black.withOpacity(0.5),
+                              light: Colors.black.withValues(alpha: 0.5),
                               brown: QPColors.brownModeMassive,
                               context: context,
                             ),

--- a/lib/pages/surat_page_v3/widgets/favorite_ayah_cta.dart
+++ b/lib/pages/surat_page_v3/widgets/favorite_ayah_cta.dart
@@ -4,10 +4,10 @@ import 'package:qurantafsir_flutter/shared/constants/theme.dart';
 
 class FavoriteAyahCTA extends StatefulWidget {
   const FavoriteAyahCTA({
-    Key? key,
+    super.key,
     required this.onTap,
     this.isFavorited = false,
-  }) : super(key: key);
+  });
 
   final VoidCallback onTap;
   final bool isFavorited;

--- a/lib/pages/surat_page_v3/widgets/post_tracking_dialog.dart
+++ b/lib/pages/surat_page_v3/widgets/post_tracking_dialog.dart
@@ -102,11 +102,10 @@ class HabitProgressPostTrackingDialog {
 
 class _PostSubmissionRemarks extends StatelessWidget {
   const _PostSubmissionRemarks({
-    Key? key,
     required this.sharedPreferenceService,
     required this.cta,
     this.isComplete = false,
-  }) : super(key: key);
+  });
 
   final SharedPreferenceService sharedPreferenceService;
   final bool isComplete;

--- a/lib/pages/surat_page_v3/widgets/pre_tracking_animation.dart
+++ b/lib/pages/surat_page_v3/widgets/pre_tracking_animation.dart
@@ -10,8 +10,7 @@ import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 import 'package:qurantafsir_flutter/widgets/button.dart';
 
 class PreHabitTrackingAnimation extends StatefulWidget {
-  const PreHabitTrackingAnimation({Key? key, required this.notifier})
-      : super(key: key);
+  const PreHabitTrackingAnimation({super.key, required this.notifier});
   final SuratPageStateNotifier notifier;
 
   @override

--- a/lib/pages/surat_page_v3/widgets/submission_dialog.dart
+++ b/lib/pages/surat_page_v3/widgets/submission_dialog.dart
@@ -8,10 +8,10 @@ import 'package:qurantafsir_flutter/widgets/button.dart';
 
 class TrackingSubmissionDialog extends StatefulWidget {
   const TrackingSubmissionDialog({
-    Key? key,
+    super.key,
     this.isFromTapBack = false,
     required this.notifier,
-  }) : super(key: key);
+  });
 
   final bool isFromTapBack;
   final SuratPageStateNotifier notifier;

--- a/lib/pages/surat_page_v3/widgets/surat_page_settings_drawer.dart
+++ b/lib/pages/surat_page_v3/widgets/surat_page_settings_drawer.dart
@@ -20,7 +20,7 @@ enum ContentType {
 
 class SuratPageSettingsDrawer extends ConsumerStatefulWidget {
   const SuratPageSettingsDrawer({
-    Key? key,
+    super.key,
     required this.onTapTranslation,
     required this.onTapTafsir,
     required this.onTapLatins,
@@ -30,7 +30,7 @@ class SuratPageSettingsDrawer extends ConsumerStatefulWidget {
     this.isWithTranslation,
     this.isWithTafsir,
     this.isWithLatins,
-  }) : super(key: key);
+  });
 
   final bool? isWithTranslation;
   final bool? isWithTafsir;
@@ -66,7 +66,7 @@ class _SuratPageSettingsDrawerState
   @override
   Widget build(BuildContext context) {
     return Drawer(
-      backgroundColor: Theme.of(context).dialogBackgroundColor,
+      backgroundColor: Theme.of(context).dialogTheme.backgroundColor,
       child: Padding(
         padding: const EdgeInsets.only(top: 60),
         child: ListView(
@@ -185,8 +185,8 @@ class _SuratPageSettingsDrawerState
               });
             },
             checkColor: checkboxDecorationColor,
-            activeColor: Theme.of(context).dialogBackgroundColor,
-            side: MaterialStateBorderSide.resolveWith(
+            activeColor: Theme.of(context).dialogTheme.backgroundColor,
+            side: WidgetStateBorderSide.resolveWith(
               (states) => BorderSide(
                 width: 1.0,
                 color: checkboxDecorationColor,
@@ -265,7 +265,7 @@ class _SuratPageSettingsDrawerState
         color: colorButton,
         boxShadow: [
           BoxShadow(
-            color: const Color(0xff000000).withOpacity(0.1),
+            color: const Color(0xff000000).withValues(alpha: 0.1),
             blurRadius: 6,
             spreadRadius: 0,
             offset: const Offset(0, 0.9),

--- a/lib/pages/tadabbur_story/tadabbur_story_state_notifier.dart
+++ b/lib/pages/tadabbur_story/tadabbur_story_state_notifier.dart
@@ -272,7 +272,7 @@ class TadabburStoryPageStateNotifier
         stackTrace,
         reason: 'error on _getListTadabburContent() method',
       );
-      print(error);
+      debugPrint(error.toString());
     }
 
     return null;

--- a/lib/pages/tadabbur_story/tadabur_story_page.dart
+++ b/lib/pages/tadabbur_story/tadabur_story_page.dart
@@ -23,8 +23,8 @@ class TadabburStoryPageParams {
 class TadabburStoryPage extends StatefulWidget {
   const TadabburStoryPage({
     required this.params,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final TadabburStoryPageParams params;
 

--- a/lib/pages/tadabbur_story/widgets/stories_widget.dart
+++ b/lib/pages/tadabbur_story/widgets/stories_widget.dart
@@ -12,8 +12,8 @@ class StoriesWidget extends StatefulWidget {
     required this.updateLatestReadStoryIndex,
     this.lastReadStoryIndex,
     this.onClose,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final VoidCallback onOpenPrevTadabbur;
   final VoidCallback onOpenNextTadabbur;

--- a/lib/pages/tadabbur_surah_list_page/tadabbur_surah_list_view.dart
+++ b/lib/pages/tadabbur_surah_list_page/tadabbur_surah_list_view.dart
@@ -11,7 +11,7 @@ import 'package:qurantafsir_flutter/shared/ui/state_notifier_connector.dart';
 import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 
 class TadabburSurahListView extends StatelessWidget {
-  const TadabburSurahListView({Key? key}) : super(key: key);
+  const TadabburSurahListView({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/tadabbur_surah_list_page/widgets/tadabbur_surah_card.dart
+++ b/lib/pages/tadabbur_surah_list_page/widgets/tadabbur_surah_card.dart
@@ -7,12 +7,12 @@ import 'package:qurantafsir_flutter/shared/utils/date_util.dart';
 
 class TadabburSurahCard extends StatelessWidget {
   const TadabburSurahCard({
-    Key? key,
+    super.key,
     required this.title,
     required this.availableTadabbur,
     required this.lastUpdatedAt,
     required this.surahID,
-  }) : super(key: key);
+  });
 
   final String title;
   final int availableTadabbur;

--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -13,6 +13,7 @@
 ///
 /// 
 ///
+library;
 import 'package:flutter/widgets.dart';
 
 class CustomIcons {

--- a/lib/shared/constants/qp_theme_data.dart
+++ b/lib/shared/constants/qp_theme_data.dart
@@ -29,7 +29,6 @@ class QPThemeData {
   static ThemeData get lightThemeData {
     return ThemeData(
       scaffoldBackgroundColor: QPColors.whiteFair,
-      dialogBackgroundColor: QPColors.whiteFair,
       dividerColor: QPColors.whiteRoot,
       hintColor: QPColors.blackSoft,
       colorScheme: const ColorScheme.light().copyWith(
@@ -37,14 +36,13 @@ class QPThemeData {
         primaryContainer: QPColors.whiteMassive,
         secondaryContainer: QPColors.whiteHeavy,
         surface: QPColors.whiteSoft,
-      ),
+      ), dialogTheme: const DialogThemeData(backgroundColor: QPColors.whiteFair),
     );
   }
 
   static ThemeData get darkThemeData {
     return ThemeData(
       scaffoldBackgroundColor: QPColors.darkModeMassive,
-      dialogBackgroundColor: QPColors.darkModeMassive,
       dividerColor: QPColors.darkModeFair,
       hintColor: QPColors.blackSoft,
       colorScheme: const ColorScheme.light().copyWith(
@@ -52,14 +50,13 @@ class QPThemeData {
         primaryContainer: QPColors.darkModeHeavy,
         secondaryContainer: QPColors.darkModeFair,
         surface: QPColors.darkModeHeavy,
-      ),
+      ), dialogTheme: const DialogThemeData(backgroundColor: QPColors.darkModeMassive),
     );
   }
 
   static ThemeData get brownThemeData {
     return ThemeData(
       scaffoldBackgroundColor: QPColors.brownModeRoot,
-      dialogBackgroundColor: QPColors.brownModeRoot,
       dividerColor: QPColors.brownModeFair,
       hintColor: QPColors.brownModeMassive,
       colorScheme: const ColorScheme.light().copyWith(
@@ -67,7 +64,7 @@ class QPThemeData {
         primaryContainer: QPColors.brownModeFair,
         secondaryContainer: QPColors.brownModeRoot,
         surface: QPColors.brownModeSoft,
-      ),
+      ), dialogTheme: const DialogThemeData(backgroundColor: QPColors.brownModeRoot),
     );
   }
 

--- a/lib/shared/core/providers.dart
+++ b/lib/shared/core/providers.dart
@@ -77,7 +77,7 @@ final Provider<TadabburApi> tadabburApiProvider = Provider<TadabburApi>((ref) {
 });
 
 final Provider<UserApi> userApiProvider =
-    Provider<UserApi>((ProviderRef<UserApi> ref) {
+    Provider<UserApi>((Ref ref) {
   final DioService dioService = ref.read(dioServiceProvider);
 
   return UserApi(
@@ -155,7 +155,7 @@ final Provider<DeepLinkService> deepLinkService =
 final StateNotifierProvider<SettingsPageStateNotifier, SettingsPageState>
     settingsPageProvider =
     StateNotifierProvider<SettingsPageStateNotifier, SettingsPageState>(
-  (StateNotifierProviderRef<SettingsPageStateNotifier, SettingsPageState> ref) {
+  (Ref ref) {
     return SettingsPageStateNotifier(
       repository: ref.watch(authenticationService),
       sharedPreferenceService: ref.watch(sharedPreferenceServiceProvider),

--- a/lib/shared/core/providers/prayer_times_notifier.dart
+++ b/lib/shared/core/providers/prayer_times_notifier.dart
@@ -45,7 +45,6 @@ class PrayerTimeState {
       case PrayerTimesList.magrib:
         return '${formatTwoDigits(prayerTimes!.maghrib.hour)}:${formatTwoDigits(prayerTimes!.maghrib.minute)}';
       case PrayerTimesList.isya:
-      default:
         return '${formatTwoDigits(prayerTimes!.isha.hour)}:${formatTwoDigits(prayerTimes!.isha.minute)}';
     }
   }

--- a/lib/shared/core/services/habit_daily_summary_service.dart
+++ b/lib/shared/core/services/habit_daily_summary_service.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:qurantafsir_flutter/shared/constants/connectivity_status_enum.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/habit_api.dart';
 import 'package:qurantafsir_flutter/shared/core/database/db_local.dart';
@@ -78,7 +79,7 @@ class HabitDailySummaryService {
         stackTrace,
         reason: 'error on syncHabit() method',
       );
-      print(error);
+      debugPrint(error.toString());
     }
   }
 

--- a/lib/shared/core/services/notification_service.dart
+++ b/lib/shared/core/services/notification_service.dart
@@ -67,7 +67,7 @@ class NotificationService {
       const NotificationDetails(
         android: androidPlatformChannelSpecifics,
       ),
-      androidAllowWhileIdle: true,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
     );

--- a/lib/shared/core/services/remote_config_service/remote_config_service.dart
+++ b/lib/shared/core/services/remote_config_service/remote_config_service.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/foundation.dart';
 import 'package:qurantafsir_flutter/firebase_options.dart';
 import 'package:qurantafsir_flutter/shared/core/services/remote_config_service/constants.dart';
 
@@ -27,7 +28,7 @@ class RemoteConfigService {
         stackTrace,
         reason: 'error on _init() method in remote config ',
       );
-      print(error);
+      debugPrint(error.toString());
     }
   }
 

--- a/lib/shared/core/state_notifiers/base_state_notifier.dart
+++ b/lib/shared/core/state_notifiers/base_state_notifier.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 abstract class BaseStateNotifier<T> extends StateNotifier<T> {
-  BaseStateNotifier(T state) : super(state);
+  BaseStateNotifier(super.state);
 
   dynamic initStateNotifier();
 }

--- a/lib/shared/core/state_notifiers/theme_state_notifier.dart
+++ b/lib/shared/core/state_notifiers/theme_state_notifier.dart
@@ -38,7 +38,6 @@ class ThemeStateNotifier extends BaseStateNotifier<QPThemeMode> {
           thirdColor: QPColors.brownModeFair,
         );
       case QPThemeMode.light:
-      default:
         return ThemeOptionColorParam(
           firstColor: QPColors.whiteSoft,
           secondColor: QPColors.whiteMassive,

--- a/lib/shared/ui/state_notifier_connector.dart
+++ b/lib/shared/ui/state_notifier_connector.dart
@@ -6,10 +6,10 @@ class StateNotifierConnector<T extends StateNotifier<P>, P>
   const StateNotifierConnector({
     required this.builder,
     required this.stateNotifierProvider,
-    Key? key,
+    super.key,
     this.child,
     this.onStateNotifierReady,
-  }) : super(key: key);
+  });
 
   final Widget Function(
     BuildContext context,

--- a/lib/widgets/adaptive_theme_dialog.dart
+++ b/lib/widgets/adaptive_theme_dialog.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 
 class AdaptiveThemeDialog extends StatelessWidget {
   const AdaptiveThemeDialog({
-    Key? key,
+    super.key,
     required this.child,
     this.borderRadiusValue = 8,
     this.contentPadding = const EdgeInsets.all(0),
-  }) : super(key: key);
+  });
 
   final Widget child;
   final double borderRadiusValue;
@@ -15,7 +15,7 @@ class AdaptiveThemeDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      backgroundColor: Theme.of(context).dialogBackgroundColor,
+      backgroundColor: Theme.of(context).dialogTheme.backgroundColor,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.all(
           Radius.circular(borderRadiusValue),

--- a/lib/widgets/app_update/force_update_dialog.dart
+++ b/lib/widgets/app_update/force_update_dialog.dart
@@ -8,8 +8,8 @@ import 'package:store_redirect/store_redirect.dart';
 
 class ForceUpdateDialog extends StatelessWidget {
   const ForceUpdateDialog({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/app_update/optional_update_dialog.dart
+++ b/lib/widgets/app_update/optional_update_dialog.dart
@@ -12,9 +12,9 @@ import 'package:version/version.dart';
 
 class OptionalUpdateDialog extends ConsumerWidget {
   const OptionalUpdateDialog({
-    Key? key,
+    super.key,
     required this.optionalMinVersion,
-  }) : super(key: key);
+  });
 
   final Version optionalMinVersion;
 

--- a/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_bottom_sheet_widget.dart
@@ -13,8 +13,8 @@ import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 
 class AudioBottomSheetWidget extends ConsumerStatefulWidget {
   const AudioBottomSheetWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   ConsumerState<AudioBottomSheetWidget> createState() =>
@@ -225,7 +225,7 @@ class _AudioBottomSheetWidgetState
           borderRadius: const BorderRadius.all(Radius.circular(100)),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: 0.1),
               blurRadius: 6,
               offset: const Offset(0, 4),
             ),
@@ -275,7 +275,7 @@ class _AudioBottomSheetWidgetState
           borderRadius: const BorderRadius.all(Radius.circular(100)),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: 0.1),
               blurRadius: 6,
               offset: const Offset(0, 4),
             ),

--- a/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_minimized_info.dart
@@ -7,10 +7,10 @@ import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_
 
 class AudioMinimizedInfo extends ConsumerStatefulWidget {
   const AudioMinimizedInfo({
-    Key? key,
+    super.key,
     required this.onClose,
     this.onTapContainer,
-  }) : super(key: key);
+  });
 
   final VoidCallback onClose;
   final VoidCallback? onTapContainer;
@@ -48,7 +48,7 @@ class _AudioMinimizedInfoState extends ConsumerState<AudioMinimizedInfo> {
           ),
           boxShadow: <BoxShadow>[
             BoxShadow(
-              color: Colors.black.withOpacity(0.3),
+              color: Colors.black.withValues(alpha: 0.3),
               blurRadius: 12,
               offset: const Offset(0, 4),
             ),

--- a/lib/widgets/audio_bottom_sheet/audio_minimized_info_icon_button.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_minimized_info_icon_button.dart
@@ -6,7 +6,7 @@ import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
 
 class AudioMinimizedInfoIconButton extends ConsumerWidget {
-  const AudioMinimizedInfoIconButton({Key? key}) : super(key: key);
+  const AudioMinimizedInfoIconButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -47,9 +47,8 @@ class AudioMinimizedInfoIconButton extends ConsumerWidget {
 
 class _IconButton extends StatelessWidget {
   const _IconButton({
-    Key? key,
     required this.icon,
-  }) : super(key: key);
+  });
 
   final IconData icon;
 

--- a/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:qurantafsir_flutter/pages/surat_page_v3/utils.dart';
@@ -162,7 +163,7 @@ class AudioRecitationStateNotifier extends StateNotifier<AudioRecitationState> {
         stackTrace,
         reason: 'error on init() method audio recitation',
       );
-      print(error);
+      debugPrint(error.toString());
       state = state.copyWith(isLoading: false);
       if (onLoadError != null) onLoadError();
     }

--- a/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
+++ b/lib/widgets/audio_bottom_sheet/linear_percent_indicator_custom.dart
@@ -7,7 +7,7 @@ import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 import 'package:qurantafsir_flutter/shared/core/providers/audio_provider.dart';
 
 class LinearPercentIndicatorCustom extends ConsumerWidget {
-  const LinearPercentIndicatorCustom({Key? key}) : super(key: key);
+  const LinearPercentIndicatorCustom({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_audio_preview_button.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_audio_preview_button.dart
@@ -3,9 +3,9 @@ import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 
 class SelectReciterAudioPreviewButton extends StatelessWidget {
   const SelectReciterAudioPreviewButton({
-    Key? key,
+    super.key,
     required this.icon,
-  }) : super(key: key);
+  });
 
   final IconData icon;
 

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_buttom_sheet.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_buttom_sheet.dart
@@ -9,7 +9,7 @@ import 'package:qurantafsir_flutter/widgets/button.dart';
 import 'package:qurantafsir_flutter/widgets/general_bottom_sheet.dart';
 
 class SelectRecitatorWidget extends ConsumerStatefulWidget {
-  const SelectRecitatorWidget({Key? key}) : super(key: key);
+  const SelectRecitatorWidget({super.key});
 
   @override
   ConsumerState<SelectRecitatorWidget> createState() =>
@@ -69,13 +69,12 @@ class _SelectRecitatorWidgetState extends ConsumerState<SelectRecitatorWidget> {
             ref.watch(audioRecitationProvider.notifier),
           );
 
-      if (context.mounted) {
-        Navigator.pop(context);
-        GeneralBottomSheet.showBaseBottomSheet(
-          context: context,
-          widgetChild: const AudioBottomSheetWidget(),
-        );
-      }
+      if (!mounted) return;
+      Navigator.pop(context);
+      GeneralBottomSheet.showBaseBottomSheet(
+        context: context,
+        widgetChild: const AudioBottomSheetWidget(),
+      );
     };
   }
 }

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_radio_button.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_radio_button.dart
@@ -10,7 +10,7 @@ import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bo
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart';
 
 class SelectReciterRadioButton extends ConsumerStatefulWidget {
-  const SelectReciterRadioButton({Key? key}) : super(key: key);
+  const SelectReciterRadioButton({super.key});
 
   @override
   ConsumerState<SelectReciterRadioButton> createState() =>
@@ -33,54 +33,57 @@ class _RadioButtonSelectReciterWidgetState
     SelectReciterBottomSheetState selectReciter =
         ref.watch(selectReciterBottomSheetProvider);
 
-    return ListView.builder(
-      itemCount: selectReciter.listReciter.length,
-      shrinkWrap: true,
-      itemBuilder: (context, index) {
-        final ReciterItemResponse item = selectReciter.listReciter[index];
+    return RadioGroup<int>(
+      groupValue: selectReciter.reciterId,
+      onChanged: (value) {
+        if (value != null) {
+          ref
+              .read(selectReciterBottomSheetProvider.notifier)
+              .updateRadioButton(
+                value,
+                selectReciter.listReciter
+                    .firstWhere((r) => r.id == value)
+                    .name,
+              );
+        }
+      },
+      child: ListView.builder(
+        itemCount: selectReciter.listReciter.length,
+        shrinkWrap: true,
+        itemBuilder: (context, index) {
+          final ReciterItemResponse item = selectReciter.listReciter[index];
 
-        return SizedBox(
-          height: 50,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                flex: 7,
-                child: Theme(
-                  data: Theme.of(context).copyWith(
-                    unselectedWidgetColor: QPColors.getColorBasedTheme(
-                      dark: QPColors.brandFair,
-                      light: QPColors.brandFair,
-                      brown: QPColors.brownModeMassive,
-                      context: context,
+          return SizedBox(
+            height: 50,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  flex: 7,
+                  child: Theme(
+                    data: Theme.of(context).copyWith(
+                      unselectedWidgetColor: QPColors.getColorBasedTheme(
+                        dark: QPColors.brandFair,
+                        light: QPColors.brandFair,
+                        brown: QPColors.brownModeMassive,
+                        context: context,
+                      ),
                     ),
-                  ),
-                  child: RadioListTile<int>(
-                    value: item.id,
-                    groupValue: selectReciter.reciterId,
-                    activeColor: QPColors.getColorBasedTheme(
-                      dark: QPColors.brandFair,
-                      light: QPColors.brandFair,
-                      brown: QPColors.brownModeMassive,
-                      context: context,
-                    ),
-                    onChanged: (value) {
-                      if (value != null) {
-                        ref
-                            .read(selectReciterBottomSheetProvider.notifier)
-                            .updateRadioButton(
-                              value,
-                              item.name,
-                            );
-                      }
-                    },
-                    title: Text(
-                      item.name,
-                      style: QPTextStyle.getSubHeading3Medium(context),
+                    child: RadioListTile<int>(
+                      value: item.id,
+                      activeColor: QPColors.getColorBasedTheme(
+                        dark: QPColors.brandFair,
+                        light: QPColors.brandFair,
+                        brown: QPColors.brownModeMassive,
+                        context: context,
+                      ),
+                      title: Text(
+                        item.name,
+                        style: QPTextStyle.getSubHeading3Medium(context),
+                      ),
                     ),
                   ),
                 ),
-              ),
               Expanded(
                 flex: 1,
                 child: buttonState.when(
@@ -118,6 +121,7 @@ class _RadioButtonSelectReciterWidgetState
           ),
         );
       },
+      ),
     );
   }
 

--- a/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart
+++ b/lib/widgets/audio_bottom_sheet/select_reciter_bottom_sheet/select_reciter_state_notifier.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/audio_api.dart';
@@ -50,11 +51,10 @@ class SelectReciterStateNotifier
     extends StateNotifier<SelectReciterBottomSheetState> {
   SelectReciterStateNotifier(
     AudioRecitationHandler audioHandler,
-    SelectReciterBottomSheetState state,
+    super.state,
     SharedPreferenceService sharedPreferenceService,
   )   : _sharedPreferenceService = sharedPreferenceService,
-        _audioHandler = audioHandler,
-        super(state);
+        _audioHandler = audioHandler;
   late AudioApi _audioApi;
   final AudioRecitationHandler _audioHandler;
   final SharedPreferenceService _sharedPreferenceService;
@@ -89,7 +89,7 @@ class SelectReciterStateNotifier
         stackTrace,
         reason: 'error on _getListTadabbur() method',
       );
-      print(error);
+      debugPrint(error.toString());
     }
   }
 

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -11,13 +11,13 @@ enum ButtonSize {
 
 class ButtonSecondary extends StatelessWidget {
   const ButtonSecondary({
-    Key? key,
+    super.key,
     required this.label,
     required this.onTap,
     this.leftIcon,
     this.textStyle,
     this.size = ButtonSize.extendable,
-  }) : super(key: key);
+  });
 
   final String? leftIcon;
   final String label;
@@ -126,12 +126,12 @@ class ButtonSecondary extends StatelessWidget {
 
 class ButtonNeutral extends StatelessWidget {
   const ButtonNeutral({
-    Key? key,
+    super.key,
     required this.label,
     required this.onTap,
     this.textStyle,
     this.size = ButtonSize.extendable,
-  }) : super(key: key);
+  });
 
   final String label;
   final Function()? onTap;
@@ -186,12 +186,12 @@ class ButtonNeutral extends StatelessWidget {
 
 class ButtonPrimary extends StatelessWidget {
   const ButtonPrimary({
-    Key? key,
+    super.key,
     required this.label,
     required this.onTap,
     this.size = ButtonSize.extendable,
     this.textStyle,
-  }) : super(key: key);
+  });
 
   final String label;
   final VoidCallback? onTap;
@@ -239,8 +239,8 @@ class ButtonBrandSoft extends StatelessWidget {
     required this.title,
     this.leftWidget,
     this.onTap,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -253,7 +253,7 @@ class ButtonBrandSoft extends StatelessWidget {
           borderRadius: const BorderRadius.all(Radius.circular(8)),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: 0.1),
               offset: const Offset(0, 0.9),
               blurRadius: 6,
               spreadRadius: 1,
@@ -283,12 +283,12 @@ class ButtonPill extends StatelessWidget {
   final Color? colorText;
 
   const ButtonPill({
-    Key? key,
+    super.key,
     required this.onTap,
     required this.label,
     this.icon,
     this.colorText,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/change_theme_bottom_sheet.dart
+++ b/lib/widgets/change_theme_bottom_sheet.dart
@@ -11,7 +11,7 @@ import 'package:qurantafsir_flutter/shared/core/providers.dart';
 import 'package:qurantafsir_flutter/widgets/utils/general_dialog.dart';
 
 class ChangeThemeBottomSheet extends ConsumerStatefulWidget {
-  const ChangeThemeBottomSheet({Key? key}) : super(key: key);
+  const ChangeThemeBottomSheet({super.key});
 
   @override
   ConsumerState<ChangeThemeBottomSheet> createState() =>
@@ -132,7 +132,9 @@ class _ChangeThemeBottomSheetState
     });
 
     await Future.delayed(const Duration(seconds: 2), () {
-      Navigator.pop(context);
+      if (mounted) {
+        Navigator.pop(context);
+      }
     });
   }
 }

--- a/lib/widgets/daily_progress_tracker.dart
+++ b/lib/widgets/daily_progress_tracker.dart
@@ -6,11 +6,11 @@ import 'package:intl/intl.dart';
 
 class DailyProgressTracker extends StatelessWidget {
   const DailyProgressTracker({
-    Key? key,
+    super.key,
     required this.target,
     required this.dailyProgress,
     required this.isNeedSync,
-  }) : super(key: key);
+  });
 
   final int target;
   final int dailyProgress;

--- a/lib/widgets/general_bottom_sheet.dart
+++ b/lib/widgets/general_bottom_sheet.dart
@@ -11,8 +11,8 @@ class BaseWidgetBottomSheet extends ConsumerStatefulWidget {
   const BaseWidgetBottomSheet({
     required this.mainAxisSize,
     required this.widgetChild,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final MainAxisSize mainAxisSize;
   final Widget widgetChild;
@@ -174,6 +174,7 @@ class GeneralBottomSheet {
     Function() onRefreshClicked,
   ) {
     return Future.delayed(Duration.zero, () {
+      if (!context.mounted) return;
       showBaseBottomSheet(
         context: context,
         widgetChild: Container(

--- a/lib/widgets/habit_group_overview.dart
+++ b/lib/widgets/habit_group_overview.dart
@@ -12,7 +12,7 @@ enum HabitGroupOverviewType {
 
 class HabitGroupOverviewWidget extends StatelessWidget {
   HabitGroupOverviewWidget({
-    Key? key,
+    super.key,
     this.groupName,
     required this.sevenDaysInformation,
     this.type = HabitGroupOverviewType.withGroupDetailInfo,
@@ -21,7 +21,7 @@ class HabitGroupOverviewWidget extends StatelessWidget {
     this.selectedIdx,
     this.totalMembers = 1,
     this.startOfEnabledDate,
-  }) : super(key: key);
+  });
 
   final String? groupName;
   final int totalMembers;

--- a/lib/widgets/habit_personal_weekly_overview.dart
+++ b/lib/widgets/habit_personal_weekly_overview.dart
@@ -12,7 +12,7 @@ enum HabitPersonalWeeklyOverviewType {
 
 class HabitPersonalWeeklyOverviewWidget extends StatefulWidget {
   const HabitPersonalWeeklyOverviewWidget({
-    Key? key,
+    super.key,
     required this.sevenDaysPersonalInfo,
     required this.type,
     this.onTapDailySummary,
@@ -20,7 +20,7 @@ class HabitPersonalWeeklyOverviewWidget extends StatefulWidget {
     this.name,
     this.startEnabledProgressDate,
     this.isAdmin = false,
-  }) : super(key: key);
+  });
 
   final List<HabitDailySummary> sevenDaysPersonalInfo;
   final HabitPersonalWeeklyOverviewType type;

--- a/lib/widgets/horizontal_divider.dart
+++ b/lib/widgets/horizontal_divider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class HorizontalDivider extends StatelessWidget {
-  const HorizontalDivider({Key? key}) : super(key: key);
+  const HorizontalDivider({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/on_boarding_widget.dart
+++ b/lib/widgets/on_boarding_widget.dart
@@ -10,8 +10,8 @@ class OnBoardingWidget extends StatefulWidget {
     required this.onBoardingKey,
     required this.child,
     required this.listWidget,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<OnBoardingWidget> createState() => _OnBoardingWidgetState();
@@ -51,7 +51,7 @@ class _OnBoardingWidgetState extends State<OnBoardingWidget> {
               child: Container(
                 width: MediaQuery.of(context).size.width,
                 height: MediaQuery.of(context).size.height,
-                color: Colors.black.withOpacity(0.8),
+                color: Colors.black.withValues(alpha: 0.8),
               ),
             ),
           if (isVisible && step < widget.listWidget.length)

--- a/lib/widgets/registration_view/registration_view.dart
+++ b/lib/widgets/registration_view/registration_view.dart
@@ -17,10 +17,10 @@ import 'package:qurantafsir_flutter/widgets/sign_in_bottom_sheet.dart';
 
 class RegistrationView extends ConsumerWidget {
   const RegistrationView({
-    Key? key,
+    super.key,
     this.onSuccessLogin,
     this.shouldNavigateTabToHome = true,
-  }) : super(key: key);
+  });
 
   final VoidCallback? onSuccessLogin;
   final bool shouldNavigateTabToHome;
@@ -157,7 +157,6 @@ class RegistrationView extends ConsumerWidget {
               );
             break;
           case SignInResult.success:
-          default:
             await ref.read(habitDailySummaryService).syncHabit(
                   connectivityStatus: connectivityStatus,
                 );

--- a/lib/widgets/registration_view/widgets/new_flag_badge.dart
+++ b/lib/widgets/registration_view/widgets/new_flag_badge.dart
@@ -3,7 +3,7 @@ import 'package:qurantafsir_flutter/shared/constants/qp_colors.dart';
 import 'package:qurantafsir_flutter/shared/constants/qp_text_style.dart';
 
 class NewFlagBadge extends StatelessWidget {
-  const NewFlagBadge({Key? key}) : super(key: key);
+  const NewFlagBadge({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/registration_view/widgets/registration_view_feature_information.dart
+++ b/lib/widgets/registration_view/widgets/registration_view_feature_information.dart
@@ -5,13 +5,13 @@ import 'package:qurantafsir_flutter/widgets/registration_view/widgets/new_flag_b
 
 class RegistrationViewFeatureInformation extends StatelessWidget {
   const RegistrationViewFeatureInformation({
-    Key? key,
+    super.key,
     this.icon,
     this.iconData,
     required this.title,
     required this.description,
     this.isNew = false,
-  }) : super(key: key);
+  });
 
   final StoredIcon? icon;
   final IconData? iconData;

--- a/lib/widgets/search_by_page_or_ayah.dart
+++ b/lib/widgets/search_by_page_or_ayah.dart
@@ -8,9 +8,9 @@ import 'package:qurantafsir_flutter/widgets/button.dart';
 
 class SearchByPageOrAyah extends StatefulWidget {
   const SearchByPageOrAyah({
-    Key? key,
+    super.key,
     required this.verseMapper,
-  }) : super(key: key);
+  });
 
   final Map<String, List<String>> verseMapper;
 

--- a/lib/widgets/step_widget.dart
+++ b/lib/widgets/step_widget.dart
@@ -39,8 +39,8 @@ class StepWidget extends StatelessWidget {
   const StepWidget({
     required this.onTapNextButton,
     required this.stepParams,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/text_field.dart
+++ b/lib/widgets/text_field.dart
@@ -8,10 +8,10 @@ class InputTotalPagesTextField extends StatelessWidget {
   final int? defaultValue;
 
   const InputTotalPagesTextField({
-    Key? key,
+    super.key,
     required this.onChanged,
     this.defaultValue,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -59,13 +59,13 @@ class InputTotalPagesTextField extends StatelessWidget {
 
 class TextFieldWithDropdown extends StatelessWidget {
   TextFieldWithDropdown({
-    Key? key,
+    super.key,
     required this.options,
     required this.onSelect,
     this.label,
     this.maxOptionsInContainer = 3,
     this.additionalInformation,
-  }) : super(key: key);
+  });
 
   final List<String> options;
   final Function(String) onSelect;
@@ -192,9 +192,8 @@ class TextFieldWithDropdown extends StatelessWidget {
 
 class _FieldLabel extends StatelessWidget {
   const _FieldLabel({
-    Key? key,
     required this.label,
-  }) : super(key: key);
+  });
 
   final String label;
 
@@ -212,7 +211,7 @@ class _FieldLabel extends StatelessWidget {
 
 class FormFieldWidget extends StatelessWidget {
   const FormFieldWidget({
-    Key? key,
+    super.key,
     this.label,
     this.additionalInformation,
     required this.onChange,
@@ -220,7 +219,7 @@ class FormFieldWidget extends StatelessWidget {
     this.iconForm,
     this.validator,
     this.initialValue,
-  }) : super(key: key);
+  });
 
   final String? label;
   final RichText? additionalInformation;

--- a/lib/widgets/theme_box_option_widget.dart
+++ b/lib/widgets/theme_box_option_widget.dart
@@ -9,8 +9,8 @@ class ThemeBoxOptionWidget extends StatelessWidget {
     required this.colorParam,
     this.onTap,
     this.isSelected = false,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
   final String theme;
   final ThemeOptionColorParam colorParam;
   final bool isSelected;


### PR DESCRIPTION
### Background

This PR addresses deprecation warnings and applies modern Dart syntax following a recent Flutter/Dart SDK upgrade. It helps keep our codebase clean and warning-free.

Refactored widget constructors codebase-wide to use `super.key` instead of the legacy `Key? key` and `: super(key: key)` verbose syntax. This resolves the `use_super_parameters` lint warnings.

* **Updated Color APIs:** 

Replaced deprecated `.withOpacity(x)` calls with the newer `Color.withValues(alpha: x)` API to adhere to the latest Flutter SDK conventions.

## Why is this necessary?
After the recent Flutter upgrade, the linter started surfacing deprecation and style warnings. Tackling these immediately prevents technical debt and keeps the developer experience smooth.


### How to Test

Please include steps of how you tested this changes

### Pre-Deployment Checklist

- [ ] Run Local OK (Mandatory)
- [ ] Run Dev Build on Real Device


### Test Checklist

- [ ] Unit Testing
- [ ] Other (Please Elaborate)

### Code Review Guidelines

https://oyteam.quip.com/4m8kAafMWWiX/Code-Review-Manifesto
