### PR TITLE
feat: track active users via device ping on app open

### DIFF
--- a/lib/pages/splash_page/splash_page_state_notifier.dart
+++ b/lib/pages/splash_page/splash_page_state_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -64,6 +66,8 @@ class SplashPageStateNotifier extends BaseStateNotifier<SplashPageState> {
           connectivityStatus == ConnectivityStatus.isConnected) {
         await _remoteConfigService.init();
         await _tadabburService.syncTadabburPerAyahInformations();
+
+        unawaited(_authenticationService.ping());
 
         if (_authenticationService.isLoggedIn) {
           await _habitDailySummaryService.syncHabit();

--- a/lib/shared/core/services/authentication_service.dart
+++ b/lib/shared/core/services/authentication_service.dart
@@ -204,6 +204,15 @@ class AuthenticationService {
     }
   }
 
+  Future<void> ping() async {
+    try {
+      final deviceId = await _sharedPreferenceService.getOrCreateDeviceId();
+      await dioServiceNotifier.state
+          .getDioWithAccessToken()
+          .post('/api/user/ping', data: {'device_id': deviceId});
+    } catch (_) {}
+  }
+
   void forceLoginAndSaveRedirectTo({
     required BuildContext context,
     required String redirectTo,

--- a/lib/shared/core/services/shared_preference_service.dart
+++ b/lib/shared/core/services/shared_preference_service.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:intl/intl.dart';
+import 'package:uuid/uuid.dart';
 import 'package:qurantafsir_flutter/shared/core/apis/model/audio.dart';
 import 'package:qurantafsir_flutter/shared/core/models/force_login_param.dart';
 import 'package:qurantafsir_flutter/shared/core/models/last_recording_data.dart';
@@ -26,6 +29,7 @@ class SharedPreferenceService {
   final String _themeKey = "theme";
   final String _dataReciter = "dataReciter";
   final String _latestPrayerTimesSynced = 'latestPrayerTimeSynced';
+  final String _deviceIdKey = 'device-id';
 
   Future<void> init() async {
     _sharedPreferences = await SharedPreferences.getInstance();
@@ -181,6 +185,19 @@ class SharedPreferenceService {
         _sharedPreferences.getString(_shownOptionalUpdateMinVersion) ?? '';
 
     return res;
+  }
+
+  Future<String> getOrCreateDeviceId() async {
+    if (Platform.isAndroid) {
+      final androidInfo = await DeviceInfoPlugin().androidInfo;
+      return androidInfo.id;
+    }
+    String? deviceId = _sharedPreferences.getString(_deviceIdKey);
+    if (deviceId == null || deviceId.isEmpty) {
+      deviceId = const Uuid().v4();
+      await _sharedPreferences.setString(_deviceIdKey, deviceId);
+    }
+    return deviceId;
   }
 
   Future<void> clear() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   connectivity_plus: ^6.0.5
   percent_indicator: ^4.2.3
   uuid: ^4.5.1
+  device_info_plus: ^10.1.0
   lottie: ^3.1.2
   wakelock_plus: ^1.2.8
   package_info_plus: ^8.0.2


### PR DESCRIPTION
## Latar Belakang

Selama ini metrik **Pengguna Aktif** di admin analytics hanya menghitung user yang menggunakan fitur **Habit Tracker**. Artinya, user yang membuka app dan membaca Quran tanpa mengaktifkan habit tracker sama sekali tidak terhitung sebagai pengguna aktif — padahal mereka jelas-jelas menggunakan aplikasi.

Ini menyebabkan angka pengguna aktif di dashboard admin menjadi **under-reported** dan tidak mencerminkan kondisi engagement yang sebenarnya.

## Solusi

Setiap kali app dibuka, Flutter mengirimkan sinyal ringan (ping) ke backend dengan `device_id` sebagai identifier. Backend mencatat aktivitas ini di tabel `user_monthly_active`, sehingga semua user — baik yang login maupun anonymous — bisa terhitung.

## Mekanisme

### Device ID

Identifier device ditentukan per platform:
- **Android**: menggunakan `ANDROID_ID` dari package `device_info_plus` — persists setelah reinstall, hanya reset saat factory reset
- **iOS**: UUID yang di-generate saat pertama kali install, disimpan di SharedPreferences

### Alur Ping

```
App dibuka (Splash Screen)
  └─ Internet tersambung?
        └─ Ya:
              ├─ remoteConfig.init()
              ├─ tadabbur.sync()
              ├─ authService.ping()   ← fire-and-forget (tidak memblokir splash screen)
              │     ├─ Ambil device_id (Android: ANDROID_ID, iOS: UUID)
              │     └─ POST /api/user/ping { device_id }
              │           + x-access-token header jika user sudah login
              └─ isLoggedIn? → habit.sync()
```

Ping bersifat **fire-and-forget** (`unawaited`) — jika gagal karena network error atau lainnya, error di-swallow dan tidak mempengaruhi pengalaman user sama sekali.

### Backend

Backend menerima ping dan melakukan upsert ke tabel `user_monthly_active`:
- Jika `x-access-token` valid → `user_id` diisi, sehingga user terdaftar dan anonymous tidak double-count
- `open_count` bertambah setiap kali app dibuka dalam bulan yang sama

### Privasi

`ANDROID_ID` digunakan untuk analytics internal (first-party) dan tidak memerlukan runtime permission. Penggunaan ini sesuai dengan Google Play policy — yang dilarang adalah penggunaan persistent identifier untuk keperluan iklan, bukan analytics internal.

## Perubahan

| File | Keterangan |
|---|---|
| `pubspec.yaml` | Tambah `device_info_plus: ^10.1.0` |
| `shared_preference_service.dart` | Tambah `getOrCreateDeviceId()` |
| `authentication_service.dart` | Tambah `ping()` |
| `splash_page_state_notifier.dart` | Panggil `unawaited(ping())` saat app dibuka |

## Test Plan

- [ ] Buka app tanpa login → cek tabel `user_monthly_active` di DB: row baru dengan `user_id = NULL`
- [ ] Buka app dengan login → cek row yang sama ter-update dengan `user_id` terisi
- [ ] Buka app berkali-kali bulan yang sama → `open_count` bertambah, bukan insert row baru
- [ ] Matikan internet → app tetap berjalan normal, tidak ada error dari ping
- [ ] Cek splash screen tidak mengalami delay akibat ping