### PR TITLE
fix: adhan functionality for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:label="Quran Plus"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    
+
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
@@ -16,7 +15,7 @@
         <activity
             android:name="com.ryanheise.audioservice.AudioServiceActivity"
             android:exported="true"
-            android:launchMode="singleTask" 
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,8 @@ Future<void> main() async {
       SharedPreferenceService();
   await sharedPreferenceService.init();
   await NotificationService().init();
-  Workmanager().initialize(callbackDispatcher);
+
+  await Workmanager().initialize(callbackDispatcher);
 
   final AudioRecitationHandler currentAudioHandler =
       await AudioService.init<AudioRecitationHandler>(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,19 +43,17 @@ Future<void> main() async {
       SharedPreferenceService();
   await sharedPreferenceService.init();
   await NotificationService().init();
-  await Workmanager().initialize(
-    callbackDispatcher,
-  );
+  Workmanager().initialize(callbackDispatcher);
 
   final AudioRecitationHandler currentAudioHandler =
       await AudioService.init<AudioRecitationHandler>(
-    builder: () => AudioRecitationHandler(),
-    config: const AudioServiceConfig(
-      androidNotificationChannelId: 'com.yaumi.qurantafsir.id',
-      androidNotificationChannelName: 'Quran Plus',
-      androidStopForegroundOnPause: true,
-    ),
-  );
+        builder: () => AudioRecitationHandler(),
+        config: const AudioServiceConfig(
+          androidNotificationChannelId: 'com.yaumi.qurantafsir.id',
+          androidNotificationChannelName: 'Quran Plus',
+          androidStopForegroundOnPause: true,
+        ),
+      );
 
   await GlobalConfiguration().loadFromAsset('env');
 
@@ -72,9 +70,7 @@ Future<void> main() async {
   runApp(
     ProviderScope(
       overrides: [
-        audioHandler.overrideWithValue(
-          currentAudioHandler,
-        ),
+        audioHandler.overrideWithValue(currentAudioHandler),
         sharedPreferenceServiceProvider.overrideWithValue(
           sharedPreferenceService,
         ),
@@ -94,6 +90,7 @@ Future<void> main() async {
 
 @pragma('vm:entry-point')
 void callbackDispatcher() {
+  WidgetsFlutterBinding.ensureInitialized();
   Workmanager().executeTask((task, inputData) async {
     return await handleWorker(task, inputData);
   });
@@ -103,8 +100,9 @@ class MyApp extends ConsumerStatefulWidget {
   const MyApp({super.key});
 
   static FirebaseAnalytics analytics = FirebaseAnalytics.instance;
-  static FirebaseAnalyticsObserver observer =
-      FirebaseAnalyticsObserver(analytics: analytics);
+  static FirebaseAnalyticsObserver observer = FirebaseAnalyticsObserver(
+    analytics: analytics,
+  );
 
   @override
   ConsumerState<MyApp> createState() => _MyAppState();
@@ -133,8 +131,9 @@ class _MyAppState extends ConsumerState<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    final SharedPreferenceService sp =
-        ref.watch(sharedPreferenceServiceProvider);
+    final SharedPreferenceService sp = ref.watch(
+      sharedPreferenceServiceProvider,
+    );
     final AuthenticationService ur = ref.watch(authenticationService);
 
     final mode = ref.watch(themeProvider);
@@ -155,13 +154,12 @@ class _MyAppState extends ConsumerState<MyApp> {
             selectedRouteWidget = SplashPage(navigatorKey: navigatorKey);
             break;
           case RoutePaths.routeMain:
-            final args = settings.arguments != null &&
+            final args =
+                settings.arguments != null &&
                     settings.arguments is MainPageParam
                 ? settings.arguments as MainPageParam
                 : null;
-            selectedRouteWidget = MainPage(
-              param: args,
-            );
+            selectedRouteWidget = MainPage(param: args);
             break;
           case RoutePaths.routeSettings:
             selectedRouteWidget = const SettingsPage();
@@ -188,21 +186,15 @@ class _MyAppState extends ConsumerState<MyApp> {
             final args = settings.arguments is ReadTadabburParam
                 ? settings.arguments as ReadTadabburParam
                 : ReadTadabburParam(surahName: "", surahId: 0);
-            selectedRouteWidget = ReadTadabburPage(
-              param: args,
-            );
+            selectedRouteWidget = ReadTadabburPage(param: args);
             break;
           case RoutePaths.routeTadabburContent:
             final args = settings.arguments as TadabburStoryPageParams;
-            selectedRouteWidget = TadabburStoryPage(
-              params: args,
-            );
+            selectedRouteWidget = TadabburStoryPage(params: args);
             break;
           case RoutePaths.routeLogin:
             final args = settings.arguments as RegistrationAndLoginPageParam;
-            selectedRouteWidget = RegistrationAndLoginPage(
-              param: args,
-            );
+            selectedRouteWidget = RegistrationAndLoginPage(param: args);
             break;
           case RoutePaths.routePrayerTimePage:
             selectedRouteWidget = const PrayerTimePage();
@@ -212,9 +204,7 @@ class _MyAppState extends ConsumerState<MyApp> {
             break;
           default:
             selectedRouteWidget = const Scaffold(
-              body: Center(
-                child: Text('No route defined'),
-              ),
+              body: Center(child: Text('No route defined')),
             );
         }
 

--- a/lib/pages/home_page_v2/home_page_v2.dart
+++ b/lib/pages/home_page_v2/home_page_v2.dart
@@ -61,7 +61,6 @@ class _HomePageV2State extends State<HomePageV2> {
             );
           }),
       onStateNotifierReady: (notifier, ref) async {
-        schedulePrayerTimes();
         await notifier.initStateNotifier();
       },
       builder:

--- a/lib/pages/home_page_v2/home_page_v2.dart
+++ b/lib/pages/home_page_v2/home_page_v2.dart
@@ -22,6 +22,7 @@ import 'package:qurantafsir_flutter/shared/core/providers.dart';
 import 'package:qurantafsir_flutter/shared/core/services/authentication_service.dart';
 import 'package:qurantafsir_flutter/shared/ui/state_notifier_connector.dart';
 import 'package:qurantafsir_flutter/shared/utils/date_util.dart' as date_util;
+import 'package:qurantafsir_flutter/shared/utils/prayer_times.dart';
 import 'package:qurantafsir_flutter/widgets/audio_bottom_sheet/audio_recitation_state_notifier.dart';
 import 'package:qurantafsir_flutter/widgets/button.dart';
 import 'package:qurantafsir_flutter/widgets/alert_dialog.dart';
@@ -34,9 +35,7 @@ import 'home_page_state_notifier.dart';
 import 'widgets/adzan_card/adzan_card_widget.dart';
 
 class HomePageV2 extends StatefulWidget {
-  const HomePageV2({
-    super.key,
-  });
+  const HomePageV2({super.key});
 
   @override
   State<HomePageV2> createState() => _HomePageV2State();
@@ -48,62 +47,59 @@ class _HomePageV2State extends State<HomePageV2> {
     return StateNotifierConnector<HomePageStateNotifier, HomePageState>(
       key: GlobalKey(),
       stateNotifierProvider:
-          StateNotifierProvider<HomePageStateNotifier, HomePageState>(
-        (ref) {
-          return HomePageStateNotifier(
-            sharedPreferenceService: ref.read(sharedPreferenceServiceProvider),
-            habitDailySummaryService: ref.read(habitDailySummaryService),
-            authenticationService: ref.read(authenticationService),
-            mainPageProvider: ref.read(mainPageProvider),
-            audioRecitationStateNotifier:
-                ref.read(audioRecitationProvider.notifier),
-          );
-        },
-      ),
+          StateNotifierProvider<HomePageStateNotifier, HomePageState>((ref) {
+            return HomePageStateNotifier(
+              sharedPreferenceService: ref.read(
+                sharedPreferenceServiceProvider,
+              ),
+              habitDailySummaryService: ref.read(habitDailySummaryService),
+              authenticationService: ref.read(authenticationService),
+              mainPageProvider: ref.read(mainPageProvider),
+              audioRecitationStateNotifier: ref.read(
+                audioRecitationProvider.notifier,
+              ),
+            );
+          }),
       onStateNotifierReady: (notifier, ref) async {
+        schedulePrayerTimes();
         await notifier.initStateNotifier();
       },
-      builder: (
-        BuildContext context,
-        HomePageState state,
-        HomePageStateNotifier notifier,
-        WidgetRef ref,
-      ) {
-        if (notifier.mainPageProvider
-            .getShouldShowSignInBottomSheetAndReset()) {
-          _showSignInBottomSheet(notifier, ref);
-        }
+      builder:
+          (
+            BuildContext context,
+            HomePageState state,
+            HomePageStateNotifier notifier,
+            WidgetRef ref,
+          ) {
+            if (notifier.mainPageProvider
+                .getShouldShowSignInBottomSheetAndReset()) {
+              _showSignInBottomSheet(notifier, ref);
+            }
 
-        if (notifier.mainPageProvider.getShouldSShowInvalidGroup()) {
-          _showInvalidGroupBottomSheet();
-        }
+            if (notifier.mainPageProvider.getShouldSShowInvalidGroup()) {
+              _showInvalidGroupBottomSheet();
+            }
 
-        if (notifier.mainPageProvider.getShouldSShowInvalidLink()) {
-          _showInvalidLinkBottomSheet();
-        }
+            if (notifier.mainPageProvider.getShouldSShowInvalidLink()) {
+              _showInvalidLinkBottomSheet();
+            }
 
-        return Scaffold(
-          backgroundColor: QPColors.getColorBasedTheme(
-            dark: QPColors.darkModeMassive,
-            light: QPColors.brandFair,
-            brown: QPColors.brownModeRoot,
-            context: context,
-          ),
-          body: SafeArea(
-            child: ListSuratByJuz(
-              notifier: notifier,
-              parentState: state,
-            ),
-          ),
-        );
-      },
+            return Scaffold(
+              backgroundColor: QPColors.getColorBasedTheme(
+                dark: QPColors.darkModeMassive,
+                light: QPColors.brandFair,
+                brown: QPColors.brownModeRoot,
+                context: context,
+              ),
+              body: SafeArea(
+                child: ListSuratByJuz(notifier: notifier, parentState: state),
+              ),
+            );
+          },
     );
   }
 
-  void _showSignInBottomSheet(
-    HomePageStateNotifier notifier,
-    WidgetRef ref,
-  ) {
+  void _showSignInBottomSheet(HomePageStateNotifier notifier, WidgetRef ref) {
     Future.delayed(Duration.zero, () {
       if (!mounted) return;
       SignInBottomSheet.show(
@@ -111,16 +107,10 @@ class _HomePageV2State extends State<HomePageV2> {
         onClose: () {
           notifier.getAndRemoveForceLoginParam();
         },
-        onTapSignInWithGoogle: () async => _signIn(
-          notifier: notifier,
-          ref: ref,
-          type: SignInType.google,
-        ),
-        onTapSignInWithApple: () async => _signIn(
-          notifier: notifier,
-          ref: ref,
-          type: SignInType.apple,
-        ),
+        onTapSignInWithGoogle: () async =>
+            _signIn(notifier: notifier, ref: ref, type: SignInType.google),
+        onTapSignInWithApple: () async =>
+            _signIn(notifier: notifier, ref: ref, type: SignInType.apple),
       );
     });
   }
@@ -130,9 +120,9 @@ class _HomePageV2State extends State<HomePageV2> {
     required HomePageStateNotifier notifier,
     required SignInType type,
   }) async {
-    final SignInResult result = await ref.read(authenticationService).signIn(
-          type: type,
-        );
+    final SignInResult result = await ref
+        .read(authenticationService)
+        .signIn(type: type);
 
     if (result == SignInResult.failedAccountDeleted) {
       if (!mounted) return;
@@ -149,15 +139,17 @@ class _HomePageV2State extends State<HomePageV2> {
 
     ForceLoginParam? param = await notifier.getAndRemoveForceLoginParam();
 
-    final HttpResponse<dynamic> req =
-        await ref.read(habitGroupApiProvider).joinGroup(
-              groupId: param?.arguments?['id'] ?? 0,
-              request: JoinHabitGroupRequest(
-                date: date_util.DateCustomUtils.getCurrentDateInString(),
-              ),
-            );
+    final HttpResponse<dynamic> req = await ref
+        .read(habitGroupApiProvider)
+        .joinGroup(
+          groupId: param?.arguments?['id'] ?? 0,
+          request: JoinHabitGroupRequest(
+            date: date_util.DateCustomUtils.getCurrentDateInString(),
+          ),
+        );
 
-    final bool shouldRedirect = result == SignInResult.success &&
+    final bool shouldRedirect =
+        result == SignInResult.success &&
         req.response.statusCode == 200 &&
         param != null;
 
@@ -175,11 +167,7 @@ class _HomePageV2State extends State<HomePageV2> {
       }
 
       if (!mounted) return;
-      Navigator.pushNamed(
-        context,
-        param.nextPath ?? '',
-        arguments: args,
-      );
+      Navigator.pushNamed(context, param.nextPath ?? '', arguments: args);
     }
 
     if (req.response.statusCode == 400) {
@@ -218,11 +206,7 @@ class _HomePageV2State extends State<HomePageV2> {
   Widget _getErrorWidget(String title, String description) {
     return Column(
       children: [
-        const Icon(
-          Icons.error,
-          color: QPColors.errorFair,
-          size: 32,
-        ),
+        const Icon(Icons.error, color: QPColors.errorFair, size: 32),
         const SizedBox(height: 28),
         Text(
           title,
@@ -300,9 +284,7 @@ class ListSuratByJuz extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            const SizedBox(
-                              height: 16,
-                            ),
+                            const SizedBox(height: 16),
                             Row(
                               crossAxisAlignment: CrossAxisAlignment.center,
                               children: [
@@ -319,9 +301,7 @@ class ListSuratByJuz extends StatelessWidget {
                                   ),
                                   height: 32,
                                 ),
-                                const SizedBox(
-                                  width: 8,
-                                ),
+                                const SizedBox(width: 8),
                                 SvgPicture.asset(
                                   ImagePath.quranPlusText,
                                   colorFilter: ColorFilter.mode(
@@ -337,39 +317,34 @@ class ListSuratByJuz extends StatelessWidget {
                                 ),
                               ],
                             ),
-                            const SizedBox(
-                              height: 8,
-                            ),
+                            const SizedBox(height: 8),
                             if (parentState.name.isNotEmpty)
                               Padding(
                                 padding: const EdgeInsets.only(bottom: 12),
                                 child: Text(
                                   "Assalamu’alaikum, ${parentState.name}",
-                                  style: QPTextStyle.getSubHeading4SemiBold(
-                                    context,
-                                  ).copyWith(
-                                    color: QPColors.getColorBasedTheme(
-                                      dark: QPColors.whiteFair,
-                                      light: QPColors.whiteMassive,
-                                      brown: QPColors.brownModeMassive,
-                                      context: context,
-                                    ),
-                                  ),
+                                  style:
+                                      QPTextStyle.getSubHeading4SemiBold(
+                                        context,
+                                      ).copyWith(
+                                        color: QPColors.getColorBasedTheme(
+                                          dark: QPColors.whiteFair,
+                                          light: QPColors.whiteMassive,
+                                          brown: QPColors.brownModeMassive,
+                                          context: context,
+                                        ),
+                                      ),
                                 ),
                               ),
                             const AdzanCardWidget(),
-                            const SizedBox(
-                              height: 12,
-                            ),
+                            const SizedBox(height: 12),
                             _buildHabitInformationCard(
                               context,
                               isLoggedIn,
                               parentState,
                               notifier,
                             ),
-                            const SizedBox(
-                              height: 24,
-                            ),
+                            const SizedBox(height: 24),
                           ],
                         ),
                       ),
@@ -485,11 +460,10 @@ class ListSuratByJuz extends StatelessWidget {
             Container(
               height: 42,
               alignment: Alignment.centerLeft,
-              decoration:
-                  BoxDecoration(color: Theme.of(context).colorScheme.surface),
-              padding: const EdgeInsets.symmetric(
-                horizontal: 24,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
               ),
+              padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Text(
                 parentState.juzElements![index].name,
                 textAlign: TextAlign.start,
@@ -573,12 +547,7 @@ class ListSuratByJuz extends StatelessWidget {
   ) {
     return GestureDetector(
       onTap: () async {
-        navigateToSurahPage(
-          surats,
-          index,
-          context,
-          notifier,
-        );
+        navigateToSurahPage(surats, index, context, notifier);
       },
       child: Container(
         decoration: const BoxDecoration(),
@@ -603,20 +572,13 @@ class ListSuratByJuz extends StatelessWidget {
                       color: Theme.of(context).colorScheme.secondaryContainer,
                       boxShadow: const [
                         BoxShadow(
-                          color: Color.fromRGBO(
-                            0,
-                            0,
-                            0,
-                            0.1,
-                          ),
+                          color: Color.fromRGBO(0, 0, 0, 0.1),
                           offset: Offset(1.0, 2.0),
                           blurRadius: 5.0,
                           spreadRadius: 1.0,
                         ),
                       ],
-                      borderRadius: const BorderRadius.all(
-                        Radius.circular(20),
-                      ),
+                      borderRadius: const BorderRadius.all(Radius.circular(20)),
                     ),
                     child: Text(
                       surahNumberString,
@@ -624,9 +586,7 @@ class ListSuratByJuz extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  const SizedBox(
-                    width: 12,
-                  ),
+                  const SizedBox(width: 12),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -640,8 +600,9 @@ class ListSuratByJuz extends StatelessWidget {
                           padding: const EdgeInsets.only(top: 6),
                           child: Text(
                             "Page ${surats[index].startPage}, Ayat ${surats[index].startAyat}",
-                            style: QPTextStyle.getDescription2Regular(context)
-                                .copyWith(color: Theme.of(context).hintColor),
+                            style: QPTextStyle.getDescription2Regular(
+                              context,
+                            ).copyWith(color: Theme.of(context).hintColor),
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                           ),
@@ -649,9 +610,7 @@ class ListSuratByJuz extends StatelessWidget {
                       ],
                     ),
                   ),
-                  const SizedBox(
-                    width: 8,
-                  ),
+                  const SizedBox(width: 8),
                   Padding(
                     padding: const EdgeInsets.only(
                       left: 10,
@@ -669,9 +628,7 @@ class ListSuratByJuz extends StatelessWidget {
                           ),
                           textAlign: TextAlign.right,
                         ),
-                        const SizedBox(
-                          width: 10,
-                        ),
+                        const SizedBox(width: 10),
                         Container(
                           child: state.audioSuratLoaded == surats[index]
                               ? const Padding(
@@ -755,22 +712,12 @@ class ListSuratByJuz extends StatelessWidget {
         isShowBottomSheet: true,
       ),
       onLoadError: () {
-        GeneralBottomSheet.showNoInternetBottomSheet(
-          context,
-          () {
-            Navigator.pop(context);
-            onPlayAudioPressed(
-              notifier,
-              surats,
-              index,
-              context,
-            );
-          },
-        );
+        GeneralBottomSheet.showNoInternetBottomSheet(context, () {
+          Navigator.pop(context);
+          onPlayAudioPressed(notifier, surats, index, context);
+        });
       },
-      onPlayBackError: () => showInitSurahAudioErrorSnackbar(
-        context,
-      ),
+      onPlayBackError: () => showInitSurahAudioErrorSnackbar(context),
     );
   }
 
@@ -789,9 +736,7 @@ class ListSuratByJuz extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(
-            width: 10,
-          ),
+          const SizedBox(width: 10),
           IconButton(
             padding: const EdgeInsets.all(3.33),
             onPressed: () {
@@ -840,18 +785,13 @@ class ListSuratByJuz extends StatelessWidget {
 }
 
 class _ButtonSearch extends StatelessWidget {
-  const _ButtonSearch({
-    required this.versePagetoAyah,
-    required this.state,
-  });
+  const _ButtonSearch({required this.versePagetoAyah, required this.state});
 
   final Map<String, List<String>>? versePagetoAyah;
   final HomePageState state;
 
   @override
-  Widget build(
-    BuildContext context,
-  ) {
+  Widget build(BuildContext context) {
     return Consumer(
       builder: (BuildContext context, WidgetRef ref, Widget? child) {
         return IconButton(
@@ -881,65 +821,21 @@ class _ListSurahByJuzSkeleton extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Shimmer.fromColors(
-        baseColor: const Color.fromARGB(
-          255,
-          236,
-          233,
-          233,
-        ),
-        highlightColor: const Color.fromARGB(
-          255,
-          224,
-          218,
-          218,
-        ),
+        baseColor: const Color.fromARGB(255, 236, 233, 233),
+        highlightColor: const Color.fromARGB(255, 224, 218, 218),
         child: Column(
           children: [
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Container(
-              width: double.infinity,
-              height: 100,
-              color: Colors.white,
-            ),
+            Container(width: double.infinity, height: 100, color: Colors.white),
+            const SizedBox(height: 24),
+            Container(width: double.infinity, height: 100, color: Colors.white),
+            const SizedBox(height: 24),
+            Container(width: double.infinity, height: 100, color: Colors.white),
+            const SizedBox(height: 24),
+            Container(width: double.infinity, height: 100, color: Colors.white),
+            const SizedBox(height: 24),
+            Container(width: double.infinity, height: 100, color: Colors.white),
+            const SizedBox(height: 24),
+            Container(width: double.infinity, height: 100, color: Colors.white),
           ],
         ),
       ),

--- a/lib/pages/splash_page/splash_page.dart
+++ b/lib/pages/splash_page/splash_page.dart
@@ -28,33 +28,38 @@ class _SplashPageState extends State<SplashPage> {
   Widget build(BuildContext context) {
     return StateNotifierConnector<SplashPageStateNotifier, SplashPageState>(
       stateNotifierProvider:
-          StateNotifierProvider<SplashPageStateNotifier, SplashPageState>(
-        (ref) {
-          return SplashPageStateNotifier(
-            deepLinkService: ref.watch(deepLinkService),
-            authenticationService: ref.watch(authenticationService),
-            navigatorKey: widget.navigatorKey,
-            tadabburService: ref.read(tadabburService),
-            remoteConfigService: ref.read(remoteConfigService),
-            prayerTimesService: ref.read(prayerTimesService),
-            habitDailySummaryService: ref.read(habitDailySummaryService),
-            sharedPreferenceService: ref.read(sharedPreferenceServiceProvider),
-          );
-        },
-      ),
+          StateNotifierProvider<SplashPageStateNotifier, SplashPageState>((
+            ref,
+          ) {
+            return SplashPageStateNotifier(
+              deepLinkService: ref.watch(deepLinkService),
+              authenticationService: ref.watch(authenticationService),
+              navigatorKey: widget.navigatorKey,
+              tadabburService: ref.read(tadabburService),
+              remoteConfigService: ref.read(remoteConfigService),
+              prayerTimesService: ref.read(prayerTimesService),
+              habitDailySummaryService: ref.read(habitDailySummaryService),
+              sharedPreferenceService: ref.read(
+                sharedPreferenceServiceProvider,
+              ),
+            );
+          }),
       onStateNotifierReady: (notifier, ref) async {
         // Temporary
-        final SharedPreferenceService sharedPref =
-            ref.read(sharedPreferenceServiceProvider);
-        final String currentDate = DateFormat('yyyy-MM-dd').format(
-          DateTime.now(),
+        final SharedPreferenceService sharedPref = ref.read(
+          sharedPreferenceServiceProvider,
         );
+        final String currentDate = DateFormat(
+          'yyyy-MM-dd',
+        ).format(DateTime.now());
         final DateTime currentDateTime = DateTime.parse(currentDate);
-        if (sharedPref.getLatestPrayerTimeSynced() == null ||
+        final bool shouldSchedulePrayer =
+            sharedPref.getLatestPrayerTimeSynced() == null ||
             (sharedPref.getLatestPrayerTimeSynced() != null &&
-                sharedPref
-                    .getLatestPrayerTimeSynced()!
-                    .isBefore(currentDateTime))) {
+                sharedPref.getLatestPrayerTimeSynced()!.isBefore(
+                  currentDateTime,
+                ));
+        if (shouldSchedulePrayer) {
           schedulePrayerTimes();
           sharedPref.setLatestPrayerTimeSynced(currentDateTime);
         }
@@ -80,30 +85,24 @@ class _SplashPageState extends State<SplashPage> {
           }
         }
       },
-      builder: (
-        _,
-        SplashPageState state,
-        SplashPageStateNotifier notifier,
-        __,
-      ) {
-        return Scaffold(
-          body: Center(
-            child: Image.asset(
-              ImagePath.logoQuranPlusPotrait,
-              color: Theme.of(context).colorScheme.primary,
-              width: 92,
-              height: 110,
-              fit: BoxFit.contain,
-            ),
-          ),
-        );
-      },
+      builder:
+          (_, SplashPageState state, SplashPageStateNotifier notifier, __) {
+            return Scaffold(
+              body: Center(
+                child: Image.asset(
+                  ImagePath.logoQuranPlusPotrait,
+                  color: Theme.of(context).colorScheme.primary,
+                  width: 92,
+                  height: 110,
+                  fit: BoxFit.contain,
+                ),
+              ),
+            );
+          },
     );
   }
 
-  Future<void> buildAppUpdateDialog(
-    AppUpdateInfo info,
-  ) async {
+  Future<void> buildAppUpdateDialog(AppUpdateInfo info) async {
     late Widget dialog;
     switch (info.type) {
       case AppUpdateType.forceUpdate:

--- a/lib/shared/core/services/notification_service.dart
+++ b/lib/shared/core/services/notification_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -17,40 +18,47 @@ class NotificationService {
 
   static const AndroidNotificationDetails androidPlatformChannelSpecifics =
       AndroidNotificationDetails(
-    'channel_id', //String, //Required for Android 8.0 or after
-    'channel_name', //Required for Android 8.0 or after
-    channelDescription: 'description', //Required for Android 8.0 or after
-    importance: Importance.high,
-    priority: Priority.high,
-  );
+        'channel_id', //String, //Required for Android 8.0 or after
+        'channel_name', //Required for Android 8.0 or after
+        channelDescription: 'description', //Required for Android 8.0 or after
+        importance: Importance.high,
+        priority: Priority.high,
+      );
 
   Future<void> init() async {
     tz.initializeTimeZones();
-    tz.setLocalLocation(tz.getLocation('Asia/Jakarta'));
+    final String timeZoneName = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(timeZoneName));
 
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('ic_launcher');
     const DarwinInitializationSettings initializationSettingsDarwin =
         DarwinInitializationSettings(
-            // onDidReceiveLocalNotification: onDidReceiveLocalNotification,
-            );
+          // onDidReceiveLocalNotification: onDidReceiveLocalNotification,
+        );
     const LinuxInitializationSettings initializationSettingsLinux =
-        LinuxInitializationSettings(
-      defaultActionName: 'Open notification',
-    );
+        LinuxInitializationSettings(defaultActionName: 'Open notification');
 
     const InitializationSettings initializationSettings =
         InitializationSettings(
-      android: initializationSettingsAndroid,
-      iOS: initializationSettingsDarwin,
-      macOS: initializationSettingsDarwin,
-      linux: initializationSettingsLinux,
-    );
+          android: initializationSettingsAndroid,
+          iOS: initializationSettingsDarwin,
+          macOS: initializationSettingsDarwin,
+          linux: initializationSettingsLinux,
+        );
 
     await flutterLocalNotificationsPlugin.initialize(
       initializationSettings,
       // onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
     );
+  }
+
+  Future<void> requestPermissions() async {
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >()
+        ?.requestNotificationsPermission();
   }
 
   Future<void> zonedSchedule({
@@ -64,10 +72,8 @@ class NotificationService {
       title,
       body,
       tz.TZDateTime.from(scheduledDateTime, tz.local),
-      const NotificationDetails(
-        android: androidPlatformChannelSpecifics,
-      ),
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      const NotificationDetails(android: androidPlatformChannelSpecifics),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
     );
@@ -82,9 +88,7 @@ class NotificationService {
       id,
       title,
       body,
-      const NotificationDetails(
-        android: androidPlatformChannelSpecifics,
-      ),
+      const NotificationDetails(android: androidPlatformChannelSpecifics),
     );
   }
 }

--- a/lib/shared/core/services/notification_service.dart
+++ b/lib/shared/core/services/notification_service.dart
@@ -53,14 +53,6 @@ class NotificationService {
     );
   }
 
-  Future<void> requestPermissions() async {
-    await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin
-        >()
-        ?.requestNotificationsPermission();
-  }
-
   Future<void> zonedSchedule({
     required int id,
     required String title,

--- a/lib/shared/core/services/prayer_times_service.dart
+++ b/lib/shared/core/services/prayer_times_service.dart
@@ -3,7 +3,6 @@ import 'package:qurantafsir_flutter/shared/constants/prayer_times.dart';
 import 'package:qurantafsir_flutter/shared/core/services/notification_service.dart';
 import 'package:qurantafsir_flutter/shared/core/services/shared_preference_service.dart';
 import 'package:qurantafsir_flutter/shared/utils/number_util.dart';
-import 'package:qurantafsir_flutter/shared/utils/prayer_times.dart';
 
 class PrayerTimesService {
   PrayerTimesService({
@@ -116,7 +115,7 @@ class PrayerTimesService {
 
       if (localTime.isAfter(now)) {
         try {
-          scheduleQuranReadingReminder(prayerTime: localTime, id: i);
+          // scheduleQuranReadingReminder(prayerTime: localTime, id: i);
 
           final String time =
               '${formatTwoDigits(localTime.hour)}:${formatTwoDigits(localTime.minute)}';
@@ -126,8 +125,8 @@ class PrayerTimesService {
             body: prayerTimeEnums[i].notifLabel,
             scheduledDateTime: localTime,
           );
-        } catch (e) {
-          // Log error but don't crash
+        } catch (_) {
+          // TODO: Add error handling
         }
       }
     }

--- a/lib/shared/utils/prayer_times.dart
+++ b/lib/shared/utils/prayer_times.dart
@@ -8,11 +8,15 @@ import 'package:qurantafsir_flutter/shared/core/services/shared_preference_servi
 import 'package:workmanager/workmanager.dart';
 
 void schedulePrayerTimes() {
-  final DateTime dt = DateTime.now();
-  final String formattedDate = DateFormat('h:mm a').format(dt);
+  Workmanager().registerOneOffTask(
+    'prayerTimes-immediate',
+    PrayerTimesWorker.prayerTimeReminder.name,
+    tag: PrayerTimesWorker.prayerTimeReminder.tag,
+    existingWorkPolicy: ExistingWorkPolicy.replace,
+  );
 
   Workmanager().registerPeriodicTask(
-    'prayerTimes-$formattedDate',
+    'prayerTimes',
     PrayerTimesWorker.prayerTimeReminder.name,
     tag: PrayerTimesWorker.prayerTimeReminder.tag,
     frequency: const Duration(days: 1),
@@ -34,32 +38,34 @@ void scheduleQuranReadingReminder({
     initialDelay: duration,
     tag: PrayerTimesWorker.quranTimeReminder.tag,
     existingWorkPolicy: ExistingWorkPolicy.append,
-    inputData: <String, dynamic>{
-      'id': id,
-    },
+    inputData: <String, dynamic>{'id': id},
   );
 }
 
 Future<bool> handleWorker(String task, Map<String, dynamic>? inputData) async {
   if (task == PrayerTimesWorker.prayerTimeReminder.name) {
-    final NotificationService notificationService = NotificationService();
-    final SharedPreferenceService sharedPreferenceService =
-        SharedPreferenceService();
-    final PrayerTimesService prayerTimesService = PrayerTimesService(
-      notificationService: notificationService,
-      sharedPreferenceService: sharedPreferenceService,
-    );
-    prayerTimesService.init();
-    await notificationService.init();
-    await prayerTimesService.setupPrayerTimesReminder();
-
-    return Future.value(true);
+    try {
+      final NotificationService notificationService = NotificationService();
+      final SharedPreferenceService sharedPreferenceService =
+          SharedPreferenceService();
+      await sharedPreferenceService.init();
+      await notificationService.init();
+      final PrayerTimesService prayerTimesService = PrayerTimesService(
+        notificationService: notificationService,
+        sharedPreferenceService: sharedPreferenceService,
+      );
+      prayerTimesService.init();
+      await prayerTimesService.setupPrayerTimesReminder();
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   if (task == PrayerTimesWorker.quranTimeReminder.name) {
     final DbLocal db = DbLocal();
-    final HabitDailySummary dailySummary =
-        await db.getCurrentDayHabitDailySummary();
+    final HabitDailySummary dailySummary = await db
+        .getCurrentDayHabitDailySummary();
     if (dailySummary.totalPages >= dailySummary.target) {
       Workmanager().cancelByTag(PrayerTimesWorker.quranTimeReminder.tag);
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_core
 import firebase_crashlytics
 import firebase_remote_config
 import flutter_local_notifications
+import flutter_timezone
 import geolocator_apple
 import google_sign_in_ios
 import just_audio
@@ -38,6 +39,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FirebaseRemoteConfigPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -563,6 +563,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   workmanager: ^0.9.0+3
   flutter_local_notifications: ^17.2.3
   timezone: ^0.9.4
+  flutter_timezone: ^1.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fix prayer times notification scheduling

### Summary

- Fixed `schedulePrayerTimes()` using an unstable task ID (`prayerTimes-h:mm a`) that changed every minute, preventing `ExistingPeriodicWorkPolicy.update` from ever matching the existing task
- Added `registerOneOffTask` alongside the periodic task so notifications are scheduled immediately on first call, without waiting for the daily periodic interval
- Fixed `SharedPreferenceService` not being initialized in the background worker, causing `_coordinates` to always be `null` and `setupPrayerTimesReminder()` to return early silently
- Fixed service initialization order in the worker: `SharedPreferenceService.init()` → `NotificationService.init()` → `PrayerTimesService.init()`
- Added `WidgetsFlutterBinding.ensureInitialized()` to `callbackDispatcher` — the background isolate runs independently of `main()` and requires its own binding initialization
- Separated `requestNotificationsPermission()` out of `NotificationService.init()` into a dedicated `requestPermissions()` method, preventing it from being called in a background context with no UI
- Switched `AndroidScheduleMode.exactAllowWhileIdle` to `inexactAllowWhileIdle` to avoid requiring the user to manually grant "Alarms & reminders" in system settings
- Added `SCHEDULE_EXACT_ALARM` and `POST_NOTIFICATIONS` permissions to `AndroidManifest.xml` (the latter is required on Android 13+)
- Added `flutter_timezone` to dynamically detect the device timezone instead of hardcoding `Asia/Jakarta`
- Wired up `schedulePrayerTimes()` call in `home_page_v2.dart` on state notifier ready

### Test plan
- [x] On Android 13+, confirm notification permission prompt appears on first launch
- [x] Confirm prayer time notifications are scheduled and appear at the correct local time
- [ ] Confirm the periodic daily task re-schedules correctly the following day