### PR TITLE
feat: auto-detect location for prayer times

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,27 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 7e9793dee1b85a243edd0e06cb1658e98b077561
-  channel: stable
+  revision: "cc0734ac716fbb8b90f3f9db8020958b1553afa7"
+  channel: "stable"
 
 project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+      base_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+    - platform: macos
+      create_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+      base_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -114,6 +114,8 @@ PODS:
     - Flutter
   - flutter_timezone (0.0.1):
     - Flutter
+  - geocoding_ios (1.0.5):
+    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -246,6 +248,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
+  - geocoding_ios (from `.symlinks/plugins/geocoding_ios/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
@@ -315,6 +318,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_timezone:
     :path: ".symlinks/plugins/flutter_timezone/ios"
+  geocoding_ios:
+    :path: ".symlinks/plugins/geocoding_ios/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_sign_in_ios:
@@ -375,6 +380,7 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_timezone: ac3da59ac941ff1c98a2e1f0293420e020120282
+  geocoding_ios: eafacae6ad11a1eb56681f7d11df602a5fd49416
   geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
   google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -40,6 +40,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>QuranPlus uses your location to compute prayer times for your area.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>The application does not use this feature</string>
 	<key>UIApplicationSceneManifest</key>

--- a/lib/pages/prayer_time_page/prayer_time.dart
+++ b/lib/pages/prayer_time_page/prayer_time.dart
@@ -16,6 +16,15 @@ class PrayerTimePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final cityName = ref.watch(prayerTimeProvider.select((s) => s.cityName));
+    final locationIsOn = ref.watch(
+      prayerTimeProvider.select((s) => s.locationIsOn),
+    );
+    final cooldownSeconds = ref.watch(
+      prayerTimeProvider.select((s) => s.updateLocationCooldownSeconds),
+    );
+    final isFetchingLocation = ref.watch(
+      prayerTimeProvider.select((s) => s.isFetchingLocation),
+    );
     final notifier = ref.read(prayerTimeProvider.notifier);
 
     return Scaffold(
@@ -169,6 +178,147 @@ class PrayerTimePage extends ConsumerWidget {
                 padding: const EdgeInsets.all(16.0),
                 child: Column(
                   children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: Text(
+                            "Auto-detect location",
+                            style: QPTextStyle.getBody2SemiBold(context)
+                                .copyWith(
+                                  color: QPColors.getColorBasedTheme(
+                                    dark: QPColors.whiteRoot,
+                                    light: QPColors.blackMassive,
+                                    brown: QPColors.brownModeMassive,
+                                    context: context,
+                                  ),
+                                ),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 36,
+                          child: FittedBox(
+                            fit: BoxFit.fitWidth,
+                            child: Switch.adaptive(
+                              activeTrackColor: QPColors.brandHeavy,
+                              inactiveThumbColor: QPColors.getColorBasedTheme(
+                                dark: QPColors.blackHeavy,
+                                light: QPColors.whiteMassive,
+                                brown: QPColors.whiteMassive,
+                                context: context,
+                              ),
+                              inactiveTrackColor: QPColors.whiteSoft,
+                              value: locationIsOn,
+                              onChanged: isFetchingLocation
+                                  ? null
+                                  : (value) async {
+                                      final messenger = ScaffoldMessenger.of(
+                                        context,
+                                      );
+                                      final ok = await notifier.setAutoDetect(
+                                        value,
+                                      );
+                                      if (!ok && value) {
+                                        messenger.showSnackBar(
+                                          const SnackBar(
+                                            content: Text(
+                                              "Couldn't access location. Please enable location permission and services, then try again.",
+                                            ),
+                                          ),
+                                        );
+                                      }
+                                    },
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (locationIsOn) ...[
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: InkWell(
+                          onTap: (cooldownSeconds > 0 || isFetchingLocation)
+                              ? null
+                              : () async {
+                                  final messenger = ScaffoldMessenger.of(
+                                    context,
+                                  );
+                                  final ok = await notifier
+                                      .updateLocationFromGps();
+                                  if (!ok) {
+                                    messenger.showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          "Couldn't update location. Please try again.",
+                                        ),
+                                      ),
+                                    );
+                                  }
+                                },
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              isFetchingLocation
+                                  ? SizedBox(
+                                      width: 14,
+                                      height: 14,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: QPColors.getColorBasedTheme(
+                                          dark: QPColors.whiteFair,
+                                          light: QPColors.brandFair,
+                                          brown: QPColors.brownModeMassive,
+                                          context: context,
+                                        ),
+                                      ),
+                                    )
+                                  : Container(
+                                      decoration: BoxDecoration(
+                                        color: QPColors.getColorBasedTheme(
+                                          dark: QPColors.whiteFair,
+                                          light: QPColors.brandFair,
+                                          brown: QPColors.brownModeMassive,
+                                          context: context,
+                                        ),
+                                        borderRadius: BorderRadius.circular(
+                                          2,
+                                        ), // Set radius here
+                                      ),
+                                      padding: const EdgeInsets.all(2),
+
+                                      child: const Icon(
+                                        Icons.refresh,
+                                        size: 10,
+                                        color: QPColors.whiteMassive,
+                                      ),
+                                    ),
+                              const SizedBox(width: 6),
+                              Text(
+                                isFetchingLocation
+                                    ? "Updating location..."
+                                    : cooldownSeconds > 0
+                                    ? "Update Location (${cooldownSeconds}s)"
+                                    : "Update Location",
+                                style:
+                                    QPTextStyle.getDescription2Medium(
+                                      context,
+                                    ).copyWith(
+                                      decoration: TextDecoration.underline,
+                                      color: QPColors.getColorBasedTheme(
+                                        dark: QPColors.whiteFair,
+                                        light: QPColors.brandFair,
+                                        brown: QPColors.brownModeMassive,
+                                        context: context,
+                                      ),
+                                    ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                    const Divider(height: 24),
                     InkWell(
                       onTap: () async {
                         await Navigator.pushNamed(
@@ -181,7 +331,7 @@ class PrayerTimePage extends ConsumerWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Text(
-                            "Set location Manually",
+                            "Set location manually",
                             style: QPTextStyle.getBody2SemiBold(context)
                                 .copyWith(
                                   color: QPColors.getColorBasedTheme(

--- a/lib/shared/core/providers/prayer_times_notifier.dart
+++ b/lib/shared/core/providers/prayer_times_notifier.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:adhan_dart/adhan_dart.dart';
+import 'package:geocoding/geocoding.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:qurantafsir_flutter/shared/constants/prayer_times.dart';
 import 'package:qurantafsir_flutter/shared/core/providers.dart';
@@ -10,30 +12,41 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'prayer_times_notifier.g.dart';
 
+const int updateLocationCooldownDurationSeconds = 30;
+
 class PrayerTimeState {
   PrayerTimeState({
     this.locationIsOn = false,
     this.isLoading = true,
     this.prayerTimes,
     this.cityName,
+    this.updateLocationCooldownSeconds = 0,
+    this.isFetchingLocation = false,
   });
 
   bool isLoading;
   bool locationIsOn;
   PrayerTimes? prayerTimes;
   String? cityName;
+  int updateLocationCooldownSeconds;
+  bool isFetchingLocation;
 
   PrayerTimeState copyWith({
     bool? isLoading,
     bool? locationIsOn,
     PrayerTimes? prayerTimes,
     String? cityName,
+    int? updateLocationCooldownSeconds,
+    bool? isFetchingLocation,
   }) {
     return PrayerTimeState(
       locationIsOn: locationIsOn ?? this.locationIsOn,
       isLoading: isLoading ?? this.isLoading,
       prayerTimes: prayerTimes ?? this.prayerTimes,
       cityName: cityName ?? this.cityName,
+      updateLocationCooldownSeconds:
+          updateLocationCooldownSeconds ?? this.updateLocationCooldownSeconds,
+      isFetchingLocation: isFetchingLocation ?? this.isFetchingLocation,
     );
   }
 
@@ -65,48 +78,179 @@ class PrayerTimeState {
 @riverpod
 class PrayerTimeNotifier extends _$PrayerTimeNotifier {
   late PrayerTimesService _prayerTimesService;
+  Timer? _cooldownTimer;
 
   @override
   PrayerTimeState build() {
     _prayerTimesService = ref.watch(prayerTimesService);
     final cityName = _prayerTimesService.getCityName();
+    final autoDetectEnabled = _prayerTimesService.getAutoDetectLocation();
+    ref.onDispose(() {
+      _cooldownTimer?.cancel();
+      _cooldownTimer = null;
+    });
+
+    if (autoDetectEnabled) {
+      Future.microtask(_silentLocationRefresh);
+    }
+
     return PrayerTimeState(
-      locationIsOn: false,
+      locationIsOn: autoDetectEnabled,
       isLoading: false,
       prayerTimes: _prayerTimesService.getPrayerTimesByDate(),
       cityName: cityName,
     );
   }
 
-  Future<void> checkGpsServices() async {
-    LocationPermission permission = await Geolocator.checkPermission();
-    bool isPermissionGiven = false;
-    bool locationCondition = false;
+  Future<void> _silentLocationRefresh() async {
+    final permission = await Geolocator.checkPermission();
+    final hasPermission =
+        permission == LocationPermission.always ||
+        permission == LocationPermission.whileInUse;
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
 
-    if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
-
-      if (permission == LocationPermission.always ||
-          permission == LocationPermission.whileInUse) {
-        isPermissionGiven = true;
-      }
+    if (!hasPermission || !serviceEnabled) {
+      await _prayerTimesService.setAutoDetectLocation(false);
+      state = state.copyWith(locationIsOn: false);
+      return;
     }
 
-    isPermissionGiven = true;
+    try {
+      final cached = await Geolocator.getLastKnownPosition();
+      if (cached != null) await _applyPosition(cached);
+    } catch (_) {}
 
-    if (isPermissionGiven) {
-      bool servicestatus = await Geolocator.isLocationServiceEnabled();
-
-      if (servicestatus) {
-        locationCondition = true;
-      }
-    }
-
-    state = state.copyWith(locationIsOn: locationCondition);
+    try {
+      final fresh = await Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+          timeLimit: Duration(seconds: 20),
+        ),
+      );
+      await _applyPosition(fresh);
+    } catch (_) {}
   }
 
-  Future<void> updateAutoDetectCondition(bool autoDetectCondition) async {
-    state = state.copyWith(locationIsOn: autoDetectCondition);
+  Future<void> _applyPosition(Position position) async {
+    final label = await _resolveCityLabel(
+      position.latitude,
+      position.longitude,
+    );
+    await changeLocation(position.latitude, position.longitude, label);
+    state = state.copyWith(
+      prayerTimes: _prayerTimesService.getPrayerTimesByDate(),
+      cityName: label,
+    );
+  }
+
+  Future<bool> setAutoDetect(bool enabled) async {
+    await _prayerTimesService.setAutoDetectLocation(enabled);
+
+    if (!enabled) {
+      state = state.copyWith(locationIsOn: false);
+      return true;
+    }
+
+    final hasPermission = await _ensureLocationPermission();
+    if (!hasPermission) {
+      await _prayerTimesService.setAutoDetectLocation(false);
+      state = state.copyWith(locationIsOn: false);
+      return false;
+    }
+
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      await _prayerTimesService.setAutoDetectLocation(false);
+      state = state.copyWith(locationIsOn: false);
+      return false;
+    }
+
+    state = state.copyWith(locationIsOn: true);
+    final fetched = await _fetchAndApplyCurrentLocation();
+    if (!fetched) {
+      await _prayerTimesService.setAutoDetectLocation(false);
+      state = state.copyWith(locationIsOn: false);
+      return false;
+    }
+    return true;
+  }
+
+  Future<bool> updateLocationFromGps() async {
+    if (state.updateLocationCooldownSeconds > 0) return false;
+
+    final fetched = await _fetchAndApplyCurrentLocation();
+    if (fetched) _startUpdateLocationCooldown();
+    return fetched;
+  }
+
+  Future<bool> _ensureLocationPermission() async {
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+    return permission == LocationPermission.always ||
+        permission == LocationPermission.whileInUse;
+  }
+
+  Future<bool> _fetchAndApplyCurrentLocation() async {
+    state = state.copyWith(isFetchingLocation: true);
+    try {
+      Position? position;
+      try {
+        position = await Geolocator.getCurrentPosition(
+          locationSettings: const LocationSettings(
+            accuracy: LocationAccuracy.high,
+            timeLimit: Duration(seconds: 20),
+          ),
+        );
+      } on TimeoutException {
+        position = await Geolocator.getLastKnownPosition();
+      }
+      if (position == null) return false;
+      await _applyPosition(position);
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      state = state.copyWith(isFetchingLocation: false);
+    }
+  }
+
+  Future<String> _resolveCityLabel(double latitude, double longitude) async {
+    try {
+      final placemarks = await placemarkFromCoordinates(latitude, longitude);
+      if (placemarks.isEmpty) return 'Current Location';
+      final p = placemarks.first;
+      final city = (p.locality?.isNotEmpty ?? false)
+          ? p.locality!
+          : (p.subAdministrativeArea?.isNotEmpty ?? false)
+          ? p.subAdministrativeArea!
+          : (p.administrativeArea ?? '');
+      final country = p.country ?? '';
+      if (city.isEmpty && country.isEmpty) return 'Current Location';
+      if (city.isEmpty) return country;
+      if (country.isEmpty) return city;
+      return '$city, $country';
+    } catch (_) {
+      return 'Current Location';
+    }
+  }
+
+  void _startUpdateLocationCooldown() {
+    _cooldownTimer?.cancel();
+    state = state.copyWith(
+      updateLocationCooldownSeconds: updateLocationCooldownDurationSeconds,
+    );
+    _cooldownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      final remaining = state.updateLocationCooldownSeconds - 1;
+      if (remaining <= 0) {
+        timer.cancel();
+        _cooldownTimer = null;
+        state = state.copyWith(updateLocationCooldownSeconds: 0);
+      } else {
+        state = state.copyWith(updateLocationCooldownSeconds: remaining);
+      }
+    });
   }
 
   Future<void> changeLocation(

--- a/lib/shared/core/services/prayer_times_service.dart
+++ b/lib/shared/core/services/prayer_times_service.dart
@@ -33,6 +33,14 @@ class PrayerTimesService {
     return sharedPreferenceService.getCityName();
   }
 
+  bool getAutoDetectLocation() {
+    return sharedPreferenceService.getAutoDetectLocation();
+  }
+
+  Future<void> setAutoDetectLocation(bool value) {
+    return sharedPreferenceService.setAutoDetectLocation(value);
+  }
+
   Future<void> setCoordinates(
     double latitude,
     double longitude,

--- a/lib/shared/core/services/shared_preference_service.dart
+++ b/lib/shared/core/services/shared_preference_service.dart
@@ -32,6 +32,7 @@ class SharedPreferenceService {
   final String _cityNameKey = "cityName";
   final String _latKey = "latKey";
   final String _lngKey = "lngKey";
+  final String _autoDetectLocationKey = "autoDetectLocation";
   final String _deviceIdKey = 'device-id';
 
   Future<void> init() async {
@@ -250,5 +251,13 @@ class SharedPreferenceService {
 
   String? getCityName() {
     return _sharedPreferences.getString(_cityNameKey);
+  }
+
+  Future<void> setAutoDetectLocation(bool value) async {
+    await _sharedPreferences.setBool(_autoDetectLocationKey, value);
+  }
+
+  bool getAutoDetectLocation() {
+    return _sharedPreferences.getBool(_autoDetectLocationKey) ?? false;
   }
 }

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -1,0 +1,12 @@
+import Cocoa
+import FlutterMacOS
+import XCTest
+
+class RunnerTests: XCTestCase {
+
+  func testExample() {
+    // If you add code to the Runner application, consider adding tests here.
+    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  }
+
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -616,6 +616,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  geocoding:
+    dependency: "direct main"
+    description:
+      name: geocoding
+      sha256: d580c801cba9386b4fac5047c4c785a4e19554f46be42f4f5e5b7deacd088a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  geocoding_android:
+    dependency: transitive
+    description:
+      name: geocoding_android
+      sha256: "1b13eca79b11c497c434678fed109c2be020b158cec7512c848c102bc7232603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  geocoding_ios:
+    dependency: transitive
+    description:
+      name: geocoding_ios
+      sha256: "18ab1c8369e2b0dcb3a8ccc907319334f35ee8cf4cfef4d9c8e23b13c65cb825"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  geocoding_platform_interface:
+    dependency: transitive
+    description:
+      name: geocoding_platform_interface
+      sha256: "8c2c8226e5c276594c2e18bfe88b19110ed770aeb7c1ab50ede570be8b92229b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   geolocator:
     dependency: "direct main"
     description:
@@ -892,10 +924,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1553,26 +1585,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.16"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
   stack_trace: ^1.12.0
   firebase_crashlytics: ^4.1.3
   geolocator: ^13.0.1
+  geocoding: ^3.0.0
   adhan_dart: ^1.2.0
   workmanager: ^0.9.0+3
   flutter_local_notifications: ^17.2.3


### PR DESCRIPTION
Closes #82.

## Summary
- Adds an **Auto-detect location** toggle on the Prayer Time page; when ON, the app uses the device GPS to compute prayer times for the user's current location and shows an **Update Location** action with a 30s cooldown.
- When the toggle is ON, `Geolocator.getCurrentPosition` (high accuracy, 20s timeout) drives `PrayerTimesService.setCoordinates` and reschedules notifications via the existing `setupPrayerTimesReminder` / `setupMultiDayPrayerTimesReminder` paths.
- Adds a silent background refresh on Prayer Time page open when the toggle is ON: tries `getLastKnownPosition` first for an instant update, then a fresh fix in the background. No spinner, no cooldown impact. If permission/service is revoked silently, the toggle flips off.
- Reverse-geocoding via the new `geocoding` dependency turns coordinates into a "City, Country" label, falling back to "Current Location" if the lookup fails (offline-first invariant preserved — prayer times still compute locally from the coordinates).
- Manual "Set location manually" entry remains available alongside the toggle so users can override.
- Fixed a pre-existing bug in `checkGpsServices` that unconditionally set `isPermissionGiven = true` regardless of the actual permission state.

## Test plan
- [ ] Fresh install on Android: open Prayer Time page → toggle ON → grant permission → city chip and prayer times update; reminders are scheduled.
- [ ] Tap **Update Location** → spinner appears, then countdown `(Ns)` ticks 30→0; button re-enables.
- [ ] Toggle OFF → Update action disappears; prayer times remain showing the last detected location; manual entry still works.
- [ ] Cold-start with toggle ON previously: page opens with last city, then silently refreshes in the background.
- [ ] Revoke location permission in system settings, relaunch: toggle flips back to OFF on next open.
- [ ] Airplane mode: toggle ON still works (GPS only); city chip falls back to "Current Location" since reverse-geocoding requires network; prayer times compute correctly.
- [ ] iOS build: location permission prompt appears on first toggle ON (uses the new `NSLocationWhenInUseUsageDescription`).
- [ ] Manual flow regression: with toggle OFF, "Set location manually" still searches and applies a city.

